### PR TITLE
feat(release): Release 订阅追踪 P1 差异化功能 (HOM-47)

### DIFF
--- a/Starcat/App/AppDependencies.swift
+++ b/Starcat/App/AppDependencies.swift
@@ -63,6 +63,19 @@ final class AppDependencies {
     /// W7+ 引入：Trending README 持久化（与 manage 路径独立的 `trending_readmes` 表）。
     let trendingReadmeRepository: TrendingReadmeRepository
 
+    // MARK: - HOM-47 Release 订阅追踪
+
+    /// Release 订阅记录 Repository。
+    let releaseSubscriptionRepository: any ReleaseSubscriptionRepositoryProtocol
+    /// Release 元数据缓存 Repository。
+    let releaseRepository: any ReleaseRepositoryProtocol
+    /// Release 巡检协调器：拉一页 Releases → 比对游标 → 写库 → 推通知。
+    let releaseMonitor: ReleaseMonitor
+    /// Release 系统通知封装（UNUserNotificationCenter）。
+    let releaseNotificationService: ReleaseNotificationService
+    /// Release 后台轮询调度器（NSBackgroundActivityScheduler）。
+    let releasePoller: ReleasePoller
+
     // MARK: - 初始化
 
     /// 生产环境构造：使用真实 DatabaseManager + 根据 useMockOAuth 选择 OAuth Service。
@@ -141,5 +154,23 @@ final class AppDependencies {
 
         // HOM-54：Trending Repository（W7+ 起接入 GRDB 持久化）
         self.trendingRepository = TrendingRepository(database: db)
+
+        // HOM-47：Release 订阅追踪。
+        // 装配顺序：Repository → Monitor（依赖 API + Repository + RepoRepository）
+        //         → NotificationService → Poller（依赖 Monitor + NotificationService）。
+        let releaseSubRepo = GRDBReleaseSubscriptionRepository(database: db)
+        self.releaseSubscriptionRepository = releaseSubRepo
+        let releaseRecordRepo = GRDBReleaseRepository(database: db)
+        self.releaseRepository = releaseRecordRepo
+        let monitor = ReleaseMonitor(
+            apiClient: api,
+            subscriptionRepo: releaseSubRepo,
+            releaseRepo: releaseRecordRepo,
+            repoRepo: repo
+        )
+        self.releaseMonitor = monitor
+        let notificationService = ReleaseNotificationService()
+        self.releaseNotificationService = notificationService
+        self.releasePoller = ReleasePoller(monitor: monitor, notificationService: notificationService)
     }
 }

--- a/Starcat/Core/Database/Migrations/DatabaseMigrationsV1.swift
+++ b/Starcat/Core/Database/Migrations/DatabaseMigrationsV1.swift
@@ -33,6 +33,75 @@ enum DatabaseMigrations {
         registerV3(into: &migrator)
         registerV4(into: &migrator)
         registerV5(into: &migrator)
+        registerV6(into: &migrator)
+    }
+
+    // MARK: - v6（HOM-47 Release 订阅追踪）
+
+    /// v6：Release 订阅追踪需要的两张表。
+    ///
+    /// **release_subscriptions**：用户对某仓库的 Release 订阅设置。
+    /// - 主键 `repo_id`：一个 repo 至多一条订阅记录
+    /// - `is_subscribed`：用户当前是否订阅
+    /// - `notify_enabled`：是否在新 Release 出现时弹系统通知（与 `is_subscribed` 解耦，
+    ///   未来可支持"订阅但静默"——MVP 默认 true）
+    /// - `last_known_release_id` / `last_known_tag_name`：上次轮询见过的最新 Release
+    ///   游标。用于在下次轮询时判断"出现了哪些新 Release 需要通知"
+    /// - `created_at` / `modified_at`：CloudKit 同步时按 Last-Write-Wins 比较 modifiedAt
+    ///
+    /// **releases**：拉到的 Release 元数据缓存。
+    /// - 主键 `id`：GitHub Release 的全局 id，跨 repo 唯一
+    /// - `repo_id` 外键 → repos.id ON DELETE CASCADE：repo 取消 star 时联级清理
+    /// - `assets_json`：把资产数组直接存 JSON 字符串。理由——assets 数量稳定 ≤ 10 条，
+    ///   只在时间线展示时需要，没有"按平台筛选所有 release 资产"的查询场景；
+    ///   开一张 release_assets 关联表会引入 N+1 与 cascade，性价比低
+    /// - `is_read`：用户已读状态。与 `repo_notes.status` 类似，UI 端默认未读
+    /// - `body_truncated`：Release notes 截取首段（最多 600 字符），用于时间线行展示
+    private static func registerV6(into migrator: inout DatabaseMigrator) {
+        migrator.registerMigration("v6-release-subscriptions") { db in
+            try createReleaseSubscriptions(db)
+            try createReleases(db)
+        }
+    }
+
+    private static func createReleaseSubscriptions(_ db: Database) throws {
+        try db.create(table: "release_subscriptions") { t in
+            t.column("repo_id", .integer).primaryKey()
+                .references("repos", column: "id", onDelete: .cascade)
+            t.column("is_subscribed", .boolean).notNull().defaults(to: true)
+            t.column("notify_enabled", .boolean).notNull().defaults(to: true)
+            t.column("last_known_release_id", .integer)
+            t.column("last_known_tag_name", .text)
+            t.column("last_polled_at", .text)
+            t.column("created_at", .text).notNull()
+            t.column("modified_at", .text).notNull()
+        }
+
+        // 时间线视图查询路径："所有 is_subscribed = 1 的订阅"
+        try db.create(index: "idx_release_subscriptions_active", on: "release_subscriptions", columns: ["is_subscribed"])
+    }
+
+    private static func createReleases(_ db: Database) throws {
+        try db.create(table: "releases") { t in
+            t.column("id", .integer).primaryKey()
+            t.column("repo_id", .integer).notNull()
+                .references("repos", column: "id", onDelete: .cascade)
+            t.column("tag_name", .text).notNull()
+            t.column("name", .text)
+            t.column("body_truncated", .text)
+            t.column("html_url", .text).notNull()
+            t.column("is_prerelease", .boolean).notNull().defaults(to: false)
+            t.column("is_draft", .boolean).notNull().defaults(to: false)
+            t.column("published_at", .text)
+            t.column("created_at_remote", .text)
+            t.column("assets_json", .text)
+            t.column("is_read", .boolean).notNull().defaults(to: false)
+            t.column("fetched_at", .text).notNull()
+        }
+
+        // 时间线主查询：按 published_at desc 排序所有订阅 repo 的 releases
+        try db.create(index: "idx_releases_repo_published", on: "releases", columns: ["repo_id", "published_at"])
+        try db.create(index: "idx_releases_published", on: "releases", columns: ["published_at"])
     }
 
     // MARK: - v5（AI 语义搜索 + 单仓智能化缓存）

--- a/Starcat/Core/Database/Models/ReleaseRecord.swift
+++ b/Starcat/Core/Database/Models/ReleaseRecord.swift
@@ -1,0 +1,133 @@
+//
+//  ReleaseRecord.swift
+//  Starcat
+//
+//  Release 缓存记录（HOM-47）。对应 `releases` 表。
+//
+//  设计取舍：
+//  - assets 用 JSON 字符串存（assets_json）。Release.assets 数量稳定 ≤ 10，
+//    没有"按平台跨 Release 反查所有资产"的查询场景；不开关联表避免 N+1
+//  - body 截断后再存（最多 600 字符），避免几 MB 的发版日志撑大数据库
+//  - is_read 是用户已读状态。和 RepoNote.status 的"未读/在读"不同：这里是 Release-level
+//
+
+import Foundation
+import GRDB
+
+struct ReleaseRecord: Codable, FetchableRecord, MutablePersistableRecord, Equatable {
+
+    static let databaseTableName = "releases"
+
+    /// GitHub Release 的全局唯一 id（不是 tag）。
+    var id: Int64
+
+    /// 关联 repos.id（ON DELETE CASCADE，repo 取消 star 时一起删除）。
+    var repoId: Int64
+
+    /// 例如 `v1.2.3`。
+    var tagName: String
+
+    /// Release 标题，可空。GitHub 允许 Release 不写名字（仅有 tag_name）。
+    var name: String?
+
+    /// 截取后的 release notes（Markdown 原文，限 600 字符）。
+    var bodyTruncated: String?
+
+    /// Release 在 GitHub 上的网页地址。
+    var htmlUrl: String
+
+    /// 是否预发布版（pre-release）。
+    var isPrerelease: Bool
+
+    /// 是否草稿（不会通过 GET releases 默认返回，但保留字段以兼容未来过滤）。
+    var isDraft: Bool
+
+    /// Release 发布时间（ISO8601 原文）。可空：草稿态没有 published_at。
+    var publishedAt: String?
+
+    /// Release 创建时间（ISO8601 原文，与 publishedAt 区分：作者可以先创建再发布）。
+    var createdAtRemote: String?
+
+    /// 资产数组的 JSON 字符串（编解码由业务层处理）。
+    /// 详见 `ReleaseAssetCodec`。
+    var assetsJson: String?
+
+    /// 用户已读状态。默认 false（未读）。
+    var isRead: Bool
+
+    /// 本地拉取时间（ISO8601）。仅作 debug，不参与同步。
+    var fetchedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case repoId = "repo_id"
+        case tagName = "tag_name"
+        case name
+        case bodyTruncated = "body_truncated"
+        case htmlUrl = "html_url"
+        case isPrerelease = "is_prerelease"
+        case isDraft = "is_draft"
+        case publishedAt = "published_at"
+        case createdAtRemote = "created_at_remote"
+        case assetsJson = "assets_json"
+        case isRead = "is_read"
+        case fetchedAt = "fetched_at"
+    }
+}
+
+// MARK: - Asset
+
+/// Release 单个资产（构件）。
+///
+/// 与 GitHub `assets` 数组中元素字段对齐，但只保留 UI 真正会展示的几列，
+/// 避免在 JSON 中存大段无用字段。
+struct ReleaseAsset: Codable, Equatable, Hashable, Identifiable {
+
+    /// GitHub asset 的全局 id（用作 SwiftUI 列表 Identifiable）。
+    var id: Int64
+
+    /// 资产文件名，如 `Starcat-1.0.0-arm64.dmg`。
+    var name: String
+
+    /// MIME 类型，可空。
+    var contentType: String?
+
+    /// 文件大小（字节）。
+    var size: Int
+
+    /// 直接下载 URL（GitHub 的 browser_download_url）。
+    var browserDownloadUrl: String
+
+    /// GitHub 统计的下载次数。
+    var downloadCount: Int
+
+    /// Asset 创建时间。
+    var createdAt: String?
+}
+
+// MARK: - Asset JSON 编解码
+
+/// 集中处理 `assets` 数组与 `assets_json` 字符串字段的相互转换。
+///
+/// 抽出来的理由：编解码场景在 Repository 写入与 ViewModel 读取两处都会用到，
+/// 避免在业务层反复 try-catch + JSONEncoder。
+enum ReleaseAssetCodec {
+
+    /// 把 assets 数组编码为 JSON 字符串（写库前调用）。
+    /// nil / 空数组都编码成 nil 入库（节省一行 `[]` 字符）。
+    static func encode(_ assets: [ReleaseAsset]?) -> String? {
+        guard let assets, !assets.isEmpty else { return nil }
+        guard let data = try? JSONEncoder().encode(assets),
+              let string = String(data: data, encoding: .utf8) else { return nil }
+        return string
+    }
+
+    /// 解析数据库中的 assets_json 字段。
+    /// 解析失败回落空数组，避免单行损坏导致整个时间线崩溃。
+    static func decode(_ raw: String?) -> [ReleaseAsset] {
+        guard let raw, !raw.isEmpty,
+              let data = raw.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([ReleaseAsset].self, from: data) else { return [] }
+        return decoded
+    }
+}

--- a/Starcat/Core/Database/Models/ReleaseSubscription.swift
+++ b/Starcat/Core/Database/Models/ReleaseSubscription.swift
@@ -1,0 +1,59 @@
+//
+//  ReleaseSubscription.swift
+//  Starcat
+//
+//  Release 订阅记录（HOM-47）。对应 `release_subscriptions` 表。
+//
+//  关键约束：
+//  - 一个 repo 最多对应一条订阅记录，故 repo_id 直接做主键
+//  - `lastKnownReleaseId` / `lastKnownTagName` 是后台轮询的"上次见过的最新 Release"游标，
+//    用来在下次轮询比对："出现了哪个 release_id ≠ lastKnown 的新 Release 需要通知"
+//    （不能仅靠时间戳判断：作者可以 backdate published_at；用 release id 单调递增更稳）
+//  - 与 CloudKit 同步设计 §2.7 对齐：`isSubscribed` / `notifyEnabled` / `modifiedAt` 都是
+//    跨端同步字段，CloudKit 接入时直接映射
+//
+
+import Foundation
+import GRDB
+
+struct ReleaseSubscription: Codable, FetchableRecord, MutablePersistableRecord, Equatable {
+
+    static let databaseTableName = "release_subscriptions"
+
+    /// 关联 repos.id。
+    var repoId: Int64
+
+    /// 是否订阅。取消订阅时 UI 应保留行（仅置 false），便于用户重新订阅时恢复
+    /// `lastKnownReleaseId` 不重新触发"补发历史 Release 通知"。
+    var isSubscribed: Bool
+
+    /// 是否在新 Release 出现时推送系统通知（与 isSubscribed 解耦，未来可"订阅但静默"）。
+    var notifyEnabled: Bool
+
+    /// 上次轮询时见过的最新 Release id（GitHub 全局唯一）。
+    /// 首次订阅时会立即拉一页 releases 并把最新一条写入这里，避免给用户补推一堆历史 Release。
+    var lastKnownReleaseId: Int64?
+
+    /// 上次见过的最新 tag_name，仅作辅助日志 / UI 展示，不参与新旧判定。
+    var lastKnownTagName: String?
+
+    /// 上次后台轮询完成时间（ISO8601）。
+    var lastPolledAt: String?
+
+    /// 订阅创建时间（ISO8601），CloudKit 同步用。
+    var createdAt: String
+
+    /// 最近修改时间（ISO8601），CloudKit Last-Write-Wins 用。
+    var modifiedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case repoId = "repo_id"
+        case isSubscribed = "is_subscribed"
+        case notifyEnabled = "notify_enabled"
+        case lastKnownReleaseId = "last_known_release_id"
+        case lastKnownTagName = "last_known_tag_name"
+        case lastPolledAt = "last_polled_at"
+        case createdAt = "created_at"
+        case modifiedAt = "modified_at"
+    }
+}

--- a/Starcat/Core/Network/GitHubAPI/GitHubAPIClientProtocol.swift
+++ b/Starcat/Core/Network/GitHubAPI/GitHubAPIClientProtocol.swift
@@ -66,6 +66,11 @@ protocol GitHubAPIClientProtocol: Sendable {
     func getSubscription(owner: String, repo: String) async throws -> GitHubSubscriptionDTO
     func putSubscription(owner: String, repo: String, subscribed: Bool, ignored: Bool) async throws -> GitHubSubscriptionDTO
     func deleteSubscription(owner: String, repo: String) async throws
+
+    // MARK: - Releases (HOM-47)
+
+    /// 拉取一页 Releases（按 GitHub 默认排序，最新在前）。
+    func releases(owner: String, repo: String, perPage: Int) async throws -> APIResponse<[GitHubReleaseDTO]>
 }
 
 // MARK: - Conformance

--- a/Starcat/Core/Network/GitHubAPI/GitHubDTOs.swift
+++ b/Starcat/Core/Network/GitHubAPI/GitHubDTOs.swift
@@ -125,3 +125,35 @@ struct GitHubSubscriptionRequestDTO: Encodable {
     let subscribed: Bool
     let ignored: Bool
 }
+
+// MARK: - Release（HOM-47）
+
+/// `GET /repos/{owner}/{repo}/releases` 单条响应。
+///
+/// 字段映射：
+/// - GitHub `id`：Release 全局唯一 id（与 tag_name 不同，tag 可重命名 / 删除重建）
+/// - GitHub `assets`：资产数组（dmg / pkg / zip 等）
+/// - 不解码 `author` / `tarball_url` / `zipball_url`：MVP 不展示，少一份解码负担
+struct GitHubReleaseDTO: Decodable, Equatable {
+    let id: Int64
+    let tagName: String
+    let name: String?
+    let body: String?
+    let htmlUrl: String
+    let prerelease: Bool
+    let draft: Bool
+    let publishedAt: String?
+    let createdAt: String?
+    let assets: [GitHubReleaseAssetDTO]?
+}
+
+/// Release 单个资产（一个可下载的构件）。
+struct GitHubReleaseAssetDTO: Decodable, Equatable {
+    let id: Int64
+    let name: String
+    let contentType: String?
+    let size: Int
+    let browserDownloadUrl: String
+    let downloadCount: Int
+    let createdAt: String?
+}

--- a/Starcat/Core/Network/GitHubAPI/ReleasesAPI.swift
+++ b/Starcat/Core/Network/GitHubAPI/ReleasesAPI.swift
@@ -1,0 +1,36 @@
+//
+//  ReleasesAPI.swift
+//  Starcat
+//
+//  GET /repos/{owner}/{repo}/releases 端点封装（HOM-47 Release 订阅追踪）。
+//
+//  设计要点：
+//  - 仅拉第一页（按 GitHub 默认排序，最新的在前）；订阅追踪关心"最近 N 条"，无需翻页
+//  - perPage 默认 10：
+//      ① 多数仓库历史 Release 数量 ≤ 10，一次拉够
+//      ② 后台轮询每个订阅 repo 都要打一次 API，控制响应体大小避免拖慢轮询
+//      ③ 如未来要"同步全量历史 Release"再加翻页支持
+//  - 不带 ETag/If-None-Match 条件请求：MVP 阶段保持简单；P2 可扩展
+//  - 404 是预期行为（仓库无任何 Release），调用方需 catch 并退化"无 Release 占位"
+//
+
+import Foundation
+
+extension GitHubAPIClient {
+
+    /// 拉取一页 Releases。
+    /// - Parameters:
+    ///   - owner: 仓库 owner（与 GitHub URL 中的 owner 一致）
+    ///   - repo: 仓库 name
+    ///   - perPage: 每页条数，默认 10，上限 100（GitHub 限制）
+    /// - Returns: APIResponse 包装 [GitHubReleaseDTO]，元素按 published_at desc 排序
+    /// - Throws: 404 → `.notFound`（无 Release）；其它 → 同 GitHubAPIClient 通用错误
+    func releases(owner: String, repo: String, perPage: Int = 10) async throws -> APIResponse<[GitHubReleaseDTO]> {
+        precondition(perPage >= 1 && perPage <= 100, "perPage must be in [1, 100]")
+        let query: [URLQueryItem] = [
+            URLQueryItem(name: "per_page", value: String(perPage)),
+            URLQueryItem(name: "page", value: "1"),
+        ]
+        return try await get(path: "/repos/\(owner)/\(repo)/releases", queryItems: query)
+    }
+}

--- a/Starcat/Core/Scheduling/ReleasePoller.swift
+++ b/Starcat/Core/Scheduling/ReleasePoller.swift
@@ -1,0 +1,123 @@
+//
+//  ReleasePoller.swift
+//  Starcat
+//
+//  后台 Release 轮询调度器（HOM-47）。
+//
+//  设计要点：
+//  - 使用 `NSBackgroundActivityScheduler`（macOS 原生 API），由系统在低负载、合适功耗的窗口期触发
+//      比 Timer 自调度更省电，符合 Apple 后台任务设计建议（见 docs/开发前问题清单 §xxx）
+//  - 默认间隔 4 小时（`tolerance` 30 分钟）；GitHub Release 发布频率远低于此，覆盖典型日常需求
+//  - 巡检入口委托给 `ReleaseMonitor.runOnce()`，本类只负责调度 + 通知派发 + 启停
+//  - App 取消所有订阅时不强制停止 scheduler（仍跑空巡）；订阅再开后立即生效
+//
+//  生命周期：
+//  - start(): 创建 scheduler 并 schedule（幂等：重复调用直接 no-op）
+//  - stop():  invalidate scheduler，释放
+//  - runNow(): 手动触发一次巡检（详情页 / 设置页 "立即检查更新" 按钮 + 单测路径）
+//
+
+import Foundation
+
+@MainActor
+final class ReleasePoller {
+
+    // MARK: - 依赖
+
+    private let monitor: ReleaseMonitor
+    private let notificationService: ReleaseNotificationService
+
+    // MARK: - 调度参数
+
+    /// 默认轮询间隔：4 小时。
+    /// 选 4 而不是 6 小时是平衡 "及时性 vs 配额 vs 功耗"：
+    /// - GitHub 5000/h 配额够支撑 ~80 个订阅 × 6 次/天的查询
+    /// - 大多数 Release 发布的"被发现 4h 内"对用户体验已足够
+    static let defaultInterval: TimeInterval = 4 * 60 * 60
+
+    /// scheduler 容差：允许系统在 [interval-tolerance, interval+tolerance] 任意时间点触发。
+    static let defaultTolerance: TimeInterval = 30 * 60
+
+    // MARK: - 状态
+
+    private var scheduler: NSBackgroundActivityScheduler?
+
+    /// 当前是否正在运行（暴露给 UI / 测试用，不影响调度）。
+    private(set) var isRunning: Bool = false
+
+    /// 上次手动 / 调度触发时间，用于 UI 展示 "上次检查于"。
+    private(set) var lastRunAt: Date?
+
+    /// 上次巡检报告（含通知列表，UI 可订阅）。
+    private(set) var lastReport: ReleaseMonitorReport?
+
+    init(monitor: ReleaseMonitor, notificationService: ReleaseNotificationService) {
+        self.monitor = monitor
+        self.notificationService = notificationService
+    }
+
+    // MARK: - 生命周期
+
+    /// 启动调度器。重复调用是 no-op。
+    func start(
+        interval: TimeInterval = ReleasePoller.defaultInterval,
+        tolerance: TimeInterval = ReleasePoller.defaultTolerance
+    ) {
+        guard scheduler == nil else { return }
+
+        let activity = NSBackgroundActivityScheduler(identifier: "\(AppConstants.bundleIdentifier).releasePoller")
+        activity.repeats = true
+        activity.interval = interval
+        activity.tolerance = tolerance
+        activity.qualityOfService = .utility
+
+        // closure 在系统选定的后台线程上跑；hop 回 main actor 后再用 monitor / state。
+        activity.schedule { [weak self] completion in
+            Task { @MainActor in
+                guard let self else {
+                    completion(.finished)
+                    return
+                }
+                await self.performScan()
+                completion(.finished)
+            }
+        }
+
+        scheduler = activity
+        isRunning = true
+        AppLog.general.info("ReleasePoller started, interval=\(Int(interval), privacy: .public)s")
+    }
+
+    /// 停止调度器（不影响已派发的通知）。
+    func stop() {
+        scheduler?.invalidate()
+        scheduler = nil
+        isRunning = false
+        AppLog.general.info("ReleasePoller stopped")
+    }
+
+    // MARK: - 立即触发
+
+    /// 手动触发一次巡检（UI / 单测调用）。
+    /// 与调度器触发走同一路径。
+    @discardableResult
+    func runNow() async -> ReleaseMonitorReport {
+        await performScan()
+        // performScan 内部已经赋值 lastReport
+        return lastReport ?? ReleaseMonitorReport(newReleasesByRepo: [:], notifications: [], perRepoErrors: [:])
+    }
+
+    // MARK: - 私有
+
+    /// 实际跑一次巡检 + 通知派发；维护 lastRunAt / lastReport 状态。
+    private func performScan() async {
+        let report = await monitor.runOnce()
+        lastRunAt = Date()
+        lastReport = report
+
+        // 把 notifications 推给系统通知中心（service 内部静默处理无授权情况）。
+        if !report.notifications.isEmpty {
+            await notificationService.dispatch(report.notifications)
+        }
+    }
+}

--- a/Starcat/Core/Sync/ReleaseMonitor.swift
+++ b/Starcat/Core/Sync/ReleaseMonitor.swift
@@ -1,0 +1,232 @@
+//
+//  ReleaseMonitor.swift
+//  Starcat
+//
+//  Release 订阅追踪 - 检测新 Release 协调器（HOM-47）。
+//
+//  职责：
+//  - 一次"巡检"：拉取所有激活订阅 → 对每个 repo 调 GitHub Releases API → 写库 → 找出新 Release
+//  - 不直接发通知（由 ReleaseNotificationService 在 ReleasePoller 中编排）
+//  - 不持有调度器引用（被 ReleasePoller / RepoReleaseSection 调用）
+//
+//  设计取舍：
+//  - 串行而非并发：避免短时内对 GitHub 5000/h 配额造成集中冲击；订阅数预计 < 100，串行总耗时可接受
+//  - 单 repo 失败不打断整体巡检：catch 后 log 继续下一个，避免 1 个仓库 404 导致全部静默
+//  - "新 Release"判定：游标 lastKnownReleaseId 之后（id > cursor）的 Release 即视为新
+//      原因：① GitHub release id 单调递增（即使作者 backdate published_at）
+//             ② 比时间戳更鲁棒，不会被时区 / 字符串排序误伤
+//
+
+import Foundation
+
+/// 一次"巡检"返回的新 Release 项（按 repo 分组）。
+///
+/// 不实现 `Equatable`：`perRepoErrors` 持有 `Error`（协议）无法等值比较，
+/// 调用方目前也只读不需要 diff，因此放弃 conformance。
+/// 改为 `@unchecked Sendable`（同样因为 `Error` 非 Sendable）—— 唯一持有点是 actor
+/// `ReleaseMonitor` 与 `ReleasePoller`，跨 actor 传递时是只读快照，安全。
+struct ReleaseMonitorReport: @unchecked Sendable {
+
+    /// 单条 "应推送通知" 项：repo + release，UI / 通知层根据 notifyEnabled 决定是否真的推。
+    struct NewReleaseItem {
+        let repo: Repo
+        let release: ReleaseRecord
+    }
+
+    /// 本次巡检在每个 repo 上发现的"新 Release"数（含已被通知静默的）。
+    var newReleasesByRepo: [Int64: Int]
+
+    /// 需要推送通知的项（已过滤 notifyEnabled=true）。
+    var notifications: [NewReleaseItem]
+
+    /// 巡检过程中遇到的非致命错误（按 repoId 分组），用于日志 / debug。
+    var perRepoErrors: [Int64: Error]
+
+    /// 结果总结：是否有 repo 出现新 Release（不含静默）。
+    var hasNewReleases: Bool {
+        !newReleasesByRepo.isEmpty
+    }
+}
+
+/// Release 巡检协调器。
+///
+/// 线程模型：actor 隔离，所有 GitHub API + DB 操作在 actor 内串行；
+/// 调用方（poller / UI）`await` 即可。
+actor ReleaseMonitor {
+
+    private let apiClient: any GitHubAPIClientProtocol
+    private let subscriptionRepo: any ReleaseSubscriptionRepositoryProtocol
+    private let releaseRepo: any ReleaseRepositoryProtocol
+    private let repoRepo: any RepoRepositoryProtocol
+
+    /// 单 repo 默认每页拉取条数。GitHub 限制 max 100，10 已足够覆盖"上次轮询以来的新增"。
+    private let perPage: Int
+
+    init(
+        apiClient: any GitHubAPIClientProtocol,
+        subscriptionRepo: any ReleaseSubscriptionRepositoryProtocol,
+        releaseRepo: any ReleaseRepositoryProtocol,
+        repoRepo: any RepoRepositoryProtocol,
+        perPage: Int = 10
+    ) {
+        self.apiClient = apiClient
+        self.subscriptionRepo = subscriptionRepo
+        self.releaseRepo = releaseRepo
+        self.repoRepo = repoRepo
+        self.perPage = perPage
+    }
+
+    /// 主入口：跑一次完整巡检。
+    /// - Returns: 报告（含每 repo 新 Release 数 + 待通知项 + 单 repo 错误）
+    @discardableResult
+    func runOnce() async -> ReleaseMonitorReport {
+        var newCounts: [Int64: Int] = [:]
+        var notifications: [ReleaseMonitorReport.NewReleaseItem] = []
+        var errors: [Int64: Error] = [:]
+
+        let subscriptions: [ReleaseSubscription]
+        do {
+            subscriptions = try await subscriptionRepo.fetchActive()
+        } catch {
+            AppLog.network.error("ReleaseMonitor: fetchActive failed: \(error.localizedDescription, privacy: .public)")
+            return ReleaseMonitorReport(
+                newReleasesByRepo: [:],
+                notifications: [],
+                perRepoErrors: [-1: error]
+            )
+        }
+
+        AppLog.network.info("ReleaseMonitor: scanning \(subscriptions.count) active subscriptions")
+
+        for subscription in subscriptions {
+            do {
+                let result = try await scanRepo(subscription)
+                if result.newCount > 0 {
+                    newCounts[subscription.repoId] = result.newCount
+                    if subscription.notifyEnabled {
+                        notifications.append(contentsOf: result.notifications)
+                    }
+                }
+            } catch {
+                errors[subscription.repoId] = error
+                AppLog.network.error("ReleaseMonitor: repo \(subscription.repoId, privacy: .public) scan failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        return ReleaseMonitorReport(
+            newReleasesByRepo: newCounts,
+            notifications: notifications,
+            perRepoErrors: errors
+        )
+    }
+
+    // MARK: - 私有：单 repo 扫描
+
+    private struct RepoScanResult {
+        let newCount: Int
+        let notifications: [ReleaseMonitorReport.NewReleaseItem]
+    }
+
+    private func scanRepo(_ subscription: ReleaseSubscription) async throws -> RepoScanResult {
+        guard let repo = try await repoRepo.findById(subscription.repoId) else {
+            // 数据已不一致（订阅指向的 repo 行被删了）—— 跳过本次，不抛错避免打断整体巡检
+            return RepoScanResult(newCount: 0, notifications: [])
+        }
+
+        // 拉一页 Releases。404 = 仓库无 Release（GitHub 行为），不抛错。
+        let dtos: [GitHubReleaseDTO]
+        do {
+            let response = try await apiClient.releases(owner: repo.owner, repo: repo.name, perPage: perPage)
+            dtos = response.value
+        } catch NetworkError.notFound {
+            // 仓库无 Release：把游标推进到"无"语义的话，未来作者发布时会被识别为新 Release（lastKnownId 仍为 nil → 全部 > nil 是 false → 不会通知）。
+            // 只更新 lastPolledAt 表明"刚轮询过"。
+            try await subscriptionRepo.updatePollCursor(
+                repoId: repo.id,
+                latestReleaseId: subscription.lastKnownReleaseId,
+                latestTagName: subscription.lastKnownTagName,
+                polledAt: Date()
+            )
+            return RepoScanResult(newCount: 0, notifications: [])
+        }
+
+        guard !dtos.isEmpty else {
+            try await subscriptionRepo.updatePollCursor(
+                repoId: repo.id,
+                latestReleaseId: subscription.lastKnownReleaseId,
+                latestTagName: subscription.lastKnownTagName,
+                polledAt: Date()
+            )
+            return RepoScanResult(newCount: 0, notifications: [])
+        }
+
+        // 转换 DTO → DB 行；并按 release id 升序排，方便确定"新 Release"分界。
+        let nowISO = ISO8601DateFormatter.shared.string(from: Date())
+        let records: [ReleaseRecord] = dtos.map { dto in
+            ReleaseRecord(
+                id: dto.id,
+                repoId: repo.id,
+                tagName: dto.tagName,
+                name: dto.name,
+                bodyTruncated: Self.truncateBody(dto.body),
+                htmlUrl: dto.htmlUrl,
+                isPrerelease: dto.prerelease,
+                isDraft: dto.draft,
+                publishedAt: dto.publishedAt,
+                createdAtRemote: dto.createdAt,
+                assetsJson: ReleaseAssetCodec.encode(dto.assets?.map(Self.dtoToAsset)),
+                isRead: false,
+                fetchedAt: nowISO
+            )
+        }
+
+        // 找出"新 Release"——id > lastKnownReleaseId 的部分。
+        // 首次轮询（cursor == nil）按"无新 Release"处理：subscribe 时已 priming 过游标。
+        let cursor = subscription.lastKnownReleaseId
+        let newRecords: [ReleaseRecord]
+        if let cursor {
+            newRecords = records.filter { $0.id > cursor }
+        } else {
+            // priming-only：游标空说明 subscribe 没传 priming（罕见）；先全部入库但不判定为"新"
+            newRecords = []
+        }
+
+        // 写库：所有 records 都 upsert（不论新旧，更新 body / assets）；
+        // is_read 默认值：新 Release → false（未读，用户能看到 badge）；
+        //                 既存 Release upsert → on conflict 不动 is_read（SQL 中 DO UPDATE 没列出 is_read）
+        try await releaseRepo.upsertMany(records, isReadDefault: false)
+
+        // 推进游标：取本次拿到的最大 release id（dtos 默认 desc 排，第一条即最大）
+        let latest = dtos.first
+        try await subscriptionRepo.updatePollCursor(
+            repoId: repo.id,
+            latestReleaseId: latest?.id ?? subscription.lastKnownReleaseId,
+            latestTagName: latest?.tagName ?? subscription.lastKnownTagName,
+            polledAt: Date()
+        )
+
+        let notifications = newRecords.map { ReleaseMonitorReport.NewReleaseItem(repo: repo, release: $0) }
+        return RepoScanResult(newCount: newRecords.count, notifications: notifications)
+    }
+
+    // MARK: - 工具
+
+    private static func truncateBody(_ body: String?) -> String? {
+        guard let body, !body.isEmpty else { return nil }
+        let limit = 600
+        if body.count <= limit { return body }
+        return String(body.prefix(limit))
+    }
+
+    private static func dtoToAsset(_ dto: GitHubReleaseAssetDTO) -> ReleaseAsset {
+        ReleaseAsset(
+            id: dto.id,
+            name: dto.name,
+            contentType: dto.contentType,
+            size: dto.size,
+            browserDownloadUrl: dto.browserDownloadUrl,
+            downloadCount: dto.downloadCount,
+            createdAt: dto.createdAt
+        )
+    }
+}

--- a/Starcat/Core/Sync/ReleaseNotificationService.swift
+++ b/Starcat/Core/Sync/ReleaseNotificationService.swift
@@ -1,0 +1,110 @@
+//
+//  ReleaseNotificationService.swift
+//  Starcat
+//
+//  Release 系统通知封装（HOM-47）。
+//
+//  目标：
+//  - 把 ReleaseMonitor 报告的 "新 Release" 转换成 macOS 系统通知（UNUserNotificationCenter）
+//  - 启动期请求一次授权，授权失败时静默不弹通知（不影响列表 / 时间线 UI）
+//  - 通知点击可识别 repo / release（userInfo 携带 id 与 url）
+//
+//  设计取舍：
+//  - 协议化（NotificationDispatching）让单测可注入 fake，避免依赖真实 UNUserNotificationCenter
+//  - 测试期 / 沙盒未授权时降级为 no-op
+//
+
+import Foundation
+@preconcurrency import UserNotifications
+
+/// 通知派发的最小协议（仅暴露 add，授权由 service 内部处理）。
+///
+/// 抽象成协议是为了：
+/// - 真实运行：UNUserNotificationCenter.current()
+/// - 单测：用 SpyNotificationDispatcher 验证"是否调用了 add 以及 content 内容"
+protocol NotificationDispatching: Sendable {
+    func requestAuthorization() async throws -> Bool
+    func add(request: UNNotificationRequest) async throws
+}
+
+/// 默认实现：包装 UNUserNotificationCenter。
+struct SystemNotificationDispatcher: NotificationDispatching {
+    func requestAuthorization() async throws -> Bool {
+        try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
+    }
+
+    func add(request: UNNotificationRequest) async throws {
+        try await UNUserNotificationCenter.current().add(request)
+    }
+}
+
+actor ReleaseNotificationService {
+
+    private let dispatcher: any NotificationDispatching
+
+    /// 是否已请求过授权（一次会话内仅请求一次）。
+    private var didRequestAuthorization = false
+
+    /// 上次授权请求结果（缓存避免重复弹系统对话框）。
+    private var isAuthorized = false
+
+    init(dispatcher: any NotificationDispatching = SystemNotificationDispatcher()) {
+        self.dispatcher = dispatcher
+    }
+
+    /// 启动期 / 首次订阅时调用。请求失败不抛错（用户拒绝是合法选择）。
+    func ensureAuthorized() async {
+        guard !didRequestAuthorization else { return }
+        didRequestAuthorization = true
+        do {
+            isAuthorized = try await dispatcher.requestAuthorization()
+            AppLog.general.info("Release notification authorization: \(self.isAuthorized, privacy: .public)")
+        } catch {
+            isAuthorized = false
+            AppLog.general.error("Release notification authorization failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// 把一个新 Release 转成通知并 dispatch。授权未通过时静默忽略。
+    /// - Parameter notifications: ReleaseMonitor 报告中的待通知项
+    func dispatch(_ notifications: [ReleaseMonitorReport.NewReleaseItem]) async {
+        guard !notifications.isEmpty else { return }
+        await ensureAuthorized()
+        guard isAuthorized else { return }
+
+        for item in notifications {
+            let content = UNMutableNotificationContent()
+            // 标题：用仓库 fullName 替代单独的 owner / name，便于用户在通知中心一眼看到来源。
+            content.title = String(format: String(localized: "release.notification.titleFormat"), item.repo.fullName)
+            content.body = makeBody(for: item.release)
+            content.sound = .default
+            content.userInfo = [
+                "repoId": item.repo.id,
+                "releaseId": item.release.id,
+                "releaseUrl": item.release.htmlUrl
+            ]
+
+            // identifier：同一个 repo 同一个 release 反复巡检都用同一个 id，
+            // 避免授权后第二轮巡检又把同一条 release 通知一次。
+            // UNUserNotificationCenter 会用 identifier 去重。
+            let request = UNNotificationRequest(
+                identifier: "release-\(item.repo.id)-\(item.release.id)",
+                content: content,
+                trigger: nil // 立即触发
+            )
+
+            do {
+                try await dispatcher.add(request: request)
+            } catch {
+                AppLog.general.error("Add release notification failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    private func makeBody(for release: ReleaseRecord) -> String {
+        if let name = release.name, !name.isEmpty, name != release.tagName {
+            return String(format: String(localized: "release.notification.bodyFormat"), release.tagName, name)
+        }
+        return release.tagName
+    }
+}

--- a/Starcat/Core/Sync/ReleaseRepository.swift
+++ b/Starcat/Core/Sync/ReleaseRepository.swift
@@ -1,0 +1,186 @@
+//
+//  ReleaseRepository.swift
+//  Starcat
+//
+//  Release 元数据缓存 Repository GRDB 实现（HOM-47）。
+//
+//  关键设计：
+//  - upsertMany 走 INSERT ... ON CONFLICT(id) DO UPDATE：同一 release 重复拉到时
+//    更新 body / assets，但**保留 is_read**（用户已读不能被刷新覆盖）
+//  - fetchTimeline 一次 JOIN 出 release + repo + subscription 三表，避免 ViewModel 端 N+1
+//
+
+import Foundation
+import GRDB
+
+struct GRDBReleaseRepository: ReleaseRepositoryProtocol {
+
+    private let writer: any DatabaseWriter
+
+    init(database: any DatabaseManaging) {
+        self.writer = database.writer
+    }
+
+    // MARK: - 查询
+
+    func latest(forRepo repoId: Int64) async throws -> ReleaseRecord? {
+        try await writer.read { db in
+            try ReleaseRecord.fetchOne(
+                db,
+                sql: """
+                SELECT * FROM releases
+                WHERE repo_id = ?
+                ORDER BY COALESCE(published_at, created_at_remote, fetched_at) DESC
+                LIMIT 1
+                """,
+                arguments: [repoId]
+            )
+        }
+    }
+
+    func fetch(forRepo repoId: Int64, limit: Int) async throws -> [ReleaseRecord] {
+        try await writer.read { db in
+            try ReleaseRecord.fetchAll(
+                db,
+                sql: """
+                SELECT * FROM releases
+                WHERE repo_id = ?
+                ORDER BY COALESCE(published_at, created_at_remote, fetched_at) DESC
+                LIMIT ?
+                """,
+                arguments: [repoId, limit]
+            )
+        }
+    }
+
+    func fetchTimeline(limit: Int) async throws -> [ReleaseTimelineEntry] {
+        try await writer.read { db in
+            // 一次 JOIN 同时拿 release + repo，避免 N+1。
+            // GRDB 不直接支持"一次 query 解码出两个 model"，这里用裸 SQL 拼成一行宽表，
+            // 再用 Row 索引手工 split 出 ReleaseRecord 与 Repo。
+            // 列顺序：先 releases.* 再 repos.*，由 SELECT 显式指定保证稳定。
+            let releaseColumns = ReleaseRecord.databaseTableName + ".*"
+            let repoColumns = Repo.databaseTableName + ".*"
+            let sql = """
+            SELECT \(releaseColumns), \(repoColumns)
+            FROM releases
+            INNER JOIN release_subscriptions ON release_subscriptions.repo_id = releases.repo_id
+            INNER JOIN repos ON repos.id = releases.repo_id
+            WHERE release_subscriptions.is_subscribed = 1
+            ORDER BY COALESCE(releases.published_at, releases.created_at_remote, releases.fetched_at) DESC
+            LIMIT ?
+            """
+            let rows = try Row.fetchAll(db, sql: sql, arguments: [limit])
+            return try rows.map { row -> ReleaseTimelineEntry in
+                // 用 ReleaseRecord 的 KeyPath 解码：先把 release 字段抠出来，避开同名列冲突。
+                // GRDB 的 Row[String] 会按列别名匹配；releases.id 与 repos.id 同名时
+                // 后者覆盖前者，所以这里逐字段读取并用 release-specific column 命名。
+                let release = ReleaseRecord(
+                    id: row["id"],
+                    repoId: row["repo_id"],
+                    tagName: row["tag_name"],
+                    name: row["name"],
+                    bodyTruncated: row["body_truncated"],
+                    htmlUrl: row["html_url"],
+                    isPrerelease: row["is_prerelease"],
+                    isDraft: row["is_draft"],
+                    publishedAt: row["published_at"],
+                    createdAtRemote: row["created_at_remote"],
+                    assetsJson: row["assets_json"],
+                    isRead: row["is_read"],
+                    fetchedAt: row["fetched_at"]
+                )
+                // repos.* 与 releases 共享几个同名列（id / html_url / created_at），
+                // 直接用 Row 解码会撞列。改为再做一次单独的 fetch，N 不会很大（time line 默认 ≤ 100 行）。
+                guard let repo = try Repo.fetchOne(db, key: release.repoId) else {
+                    throw ReleaseRepositoryError.timelineRepoMissing(repoId: release.repoId)
+                }
+                return ReleaseTimelineEntry(release: release, repo: repo)
+            }
+        }
+    }
+
+    func unreadCount() async throws -> Int {
+        try await writer.read { db in
+            try Int.fetchOne(db, sql: """
+                SELECT COUNT(*) FROM releases r
+                INNER JOIN release_subscriptions s ON s.repo_id = r.repo_id
+                WHERE s.is_subscribed = 1 AND r.is_read = 0
+                """) ?? 0
+        }
+    }
+
+    // MARK: - 写入
+
+    func upsertMany(_ records: [ReleaseRecord], isReadDefault: Bool) async throws {
+        guard !records.isEmpty else { return }
+        try await writer.write { db in
+            for record in records {
+                try db.execute(
+                    sql: """
+                    INSERT INTO releases (
+                        id, repo_id, tag_name, name, body_truncated, html_url,
+                        is_prerelease, is_draft, published_at, created_at_remote,
+                        assets_json, is_read, fetched_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(id) DO UPDATE SET
+                        tag_name = excluded.tag_name,
+                        name = excluded.name,
+                        body_truncated = excluded.body_truncated,
+                        html_url = excluded.html_url,
+                        is_prerelease = excluded.is_prerelease,
+                        is_draft = excluded.is_draft,
+                        published_at = excluded.published_at,
+                        created_at_remote = excluded.created_at_remote,
+                        assets_json = excluded.assets_json,
+                        fetched_at = excluded.fetched_at
+                    """,
+                    arguments: [
+                        record.id, record.repoId, record.tagName, record.name,
+                        record.bodyTruncated, record.htmlUrl,
+                        record.isPrerelease ? 1 : 0, record.isDraft ? 1 : 0,
+                        record.publishedAt, record.createdAtRemote,
+                        record.assetsJson, isReadDefault ? 1 : 0, record.fetchedAt
+                    ]
+                )
+            }
+        }
+    }
+
+    func markRead(releaseId: Int64, isRead: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE releases SET is_read = ? WHERE id = ?",
+                arguments: [isRead ? 1 : 0, releaseId]
+            )
+        }
+    }
+
+    func markAllRead(forRepo repoId: Int64) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE releases SET is_read = 1 WHERE repo_id = ?",
+                arguments: [repoId]
+            )
+        }
+    }
+
+    func markAllRead() async throws {
+        try await writer.write { db in
+            try db.execute(sql: "UPDATE releases SET is_read = 1")
+        }
+    }
+}
+
+// MARK: - Errors
+
+enum ReleaseRepositoryError: Error, LocalizedError {
+    case timelineRepoMissing(repoId: Int64)
+
+    var errorDescription: String? {
+        switch self {
+        case .timelineRepoMissing(let id):
+            return "Release timeline missing repo \(id)"
+        }
+    }
+}

--- a/Starcat/Core/Sync/ReleaseRepositoryProtocol.swift
+++ b/Starcat/Core/Sync/ReleaseRepositoryProtocol.swift
@@ -1,0 +1,58 @@
+//
+//  ReleaseRepositoryProtocol.swift
+//  Starcat
+//
+//  Release 元数据缓存 Repository 协议（HOM-47）。
+//
+//  关注点：
+//  - 缓存"已订阅 repo 的 Release 列表"，时间线视图直接读，不打 GitHub API
+//  - 已读 / 未读由 `markRead(_:)` 显式翻转
+//  - Repository 不感知"何时应该再次拉取"——那是 ReleaseMonitor 的责任
+//
+
+import Foundation
+
+/// 时间线视图行：把 Release + 它所属的 repo 一起返回，避免 UI 端再做 N+1 查询。
+struct ReleaseTimelineEntry: Equatable, Identifiable {
+    var release: ReleaseRecord
+    var repo: Repo
+
+    /// 复用 release.id 作为 SwiftUI list identity。
+    var id: Int64 { release.id }
+}
+
+protocol ReleaseRepositoryProtocol: Sendable {
+
+    // MARK: - 查询
+
+    /// 取某 repo 缓存到的最新一条 Release（按 published_at desc 取首条）。
+    func latest(forRepo repoId: Int64) async throws -> ReleaseRecord?
+
+    /// 取某 repo 缓存到的所有 Releases，按 published_at desc。
+    func fetch(forRepo repoId: Int64, limit: Int) async throws -> [ReleaseRecord]
+
+    /// 时间线主查询：仅返回当前订阅且 is_subscribed=1 的 repo 的所有 Release。
+    /// 联表 repos + release_subscriptions，按 published_at desc 排序，limit 截断。
+    func fetchTimeline(limit: Int) async throws -> [ReleaseTimelineEntry]
+
+    /// 当前未读 release 总数（用于 Sidebar Badge）。
+    /// 仅统计当前订阅 repo（is_subscribed=1）下的 is_read=0 行。
+    func unreadCount() async throws -> Int
+
+    // MARK: - 写入
+
+    /// 把后台轮询拿到的 Release 列表写库（INSERT OR REPLACE 形式）。
+    /// `isReadDefault` 控制新插入行的 is_read：
+    /// - 后台轮询发现新 Release：传 false（保持未读，让用户看 badge）
+    /// - 首次订阅 priming 拉取（不通知用户）：传 true（直接标已读，避免一打开时间线全是高亮）
+    func upsertMany(_ records: [ReleaseRecord], isReadDefault: Bool) async throws
+
+    /// 标记单个 Release 为已读 / 未读。
+    func markRead(releaseId: Int64, isRead: Bool) async throws
+
+    /// 标记某 repo 下所有 Release 为已读（详情页"清未读"按钮）。
+    func markAllRead(forRepo repoId: Int64) async throws
+
+    /// 标记所有订阅下的 Release 为已读（时间线"全部已读"）。
+    func markAllRead() async throws
+}

--- a/Starcat/Core/Sync/ReleaseSubscriptionRepository.swift
+++ b/Starcat/Core/Sync/ReleaseSubscriptionRepository.swift
@@ -1,0 +1,136 @@
+//
+//  ReleaseSubscriptionRepository.swift
+//  Starcat
+//
+//  Release 订阅 Repository GRDB 实现（HOM-47）。
+//
+//  schema 对照（DatabaseMigrationsV1.createReleaseSubscriptions）：
+//    repo_id INTEGER PRIMARY KEY → repos.id ON DELETE CASCADE
+//    is_subscribed BOOLEAN NOT NULL DEFAULT 1
+//    notify_enabled BOOLEAN NOT NULL DEFAULT 1
+//    last_known_release_id INTEGER
+//    last_known_tag_name TEXT
+//    last_polled_at TEXT
+//    created_at TEXT NOT NULL
+//    modified_at TEXT NOT NULL
+//
+
+import Foundation
+import GRDB
+
+struct GRDBReleaseSubscriptionRepository: ReleaseSubscriptionRepositoryProtocol {
+
+    private let writer: any DatabaseWriter
+
+    init(database: any DatabaseManaging) {
+        self.writer = database.writer
+    }
+
+    // MARK: - 查询
+
+    func find(repoId: Int64) async throws -> ReleaseSubscription? {
+        try await writer.read { db in
+            try ReleaseSubscription.fetchOne(db, key: repoId)
+        }
+    }
+
+    func fetchActive() async throws -> [ReleaseSubscription] {
+        try await writer.read { db in
+            try ReleaseSubscription.fetchAll(
+                db,
+                sql: "SELECT * FROM release_subscriptions WHERE is_subscribed = 1"
+            )
+        }
+    }
+
+    func fetchAll() async throws -> [ReleaseSubscription] {
+        try await writer.read { db in
+            try ReleaseSubscription.fetchAll(db)
+        }
+    }
+
+    // MARK: - 写入
+
+    /// 订阅 / 重新订阅。
+    ///
+    /// 三种情况，都用 UPSERT 一条 SQL 处理：
+    /// 1. 行不存在：INSERT 一行，is_subscribed=1，写入 lastKnown 游标 + 双时间戳
+    /// 2. 行存在但 is_subscribed=0（之前取消过）：仅 UPDATE is_subscribed=1 + modifiedAt，
+    ///    保留原 lastKnownReleaseId（如调用方想"重新订阅时仍按上次见过的最新 release 计算新增"）；
+    ///    若 primingReleaseId 非 nil 也会一并更新（调用方决定是否覆盖）
+    /// 3. 行存在且 is_subscribed=1（重复订阅）：modifiedAt 推进，game-no-op
+    ///
+    /// primingReleaseId 设计：首次订阅必传 `nil` 之外的"当前最新 release id"，
+    /// 否则下一次轮询会把仓库历史所有 Release 当成"新 Release"批量推通知给用户。
+    func subscribe(repoId: Int64, primingReleaseId: Int64?, primingTagName: String?) async throws {
+        let nowISO = ISO8601DateFormatter.shared.string(from: Date())
+        try await writer.write { db in
+            try db.execute(
+                sql: """
+                INSERT INTO release_subscriptions (
+                    repo_id, is_subscribed, notify_enabled,
+                    last_known_release_id, last_known_tag_name, last_polled_at,
+                    created_at, modified_at
+                ) VALUES (?, 1, 1, ?, ?, NULL, ?, ?)
+                ON CONFLICT(repo_id) DO UPDATE SET
+                    is_subscribed = 1,
+                    last_known_release_id = COALESCE(excluded.last_known_release_id, last_known_release_id),
+                    last_known_tag_name = COALESCE(excluded.last_known_tag_name, last_known_tag_name),
+                    modified_at = excluded.modified_at
+                """,
+                arguments: [repoId, primingReleaseId, primingTagName, nowISO, nowISO]
+            )
+        }
+    }
+
+    func unsubscribe(repoId: Int64) async throws {
+        let nowISO = ISO8601DateFormatter.shared.string(from: Date())
+        try await writer.write { db in
+            try db.execute(
+                sql: """
+                UPDATE release_subscriptions
+                SET is_subscribed = 0, modified_at = ?
+                WHERE repo_id = ?
+                """,
+                arguments: [nowISO, repoId]
+            )
+        }
+    }
+
+    func setNotifyEnabled(repoId: Int64, enabled: Bool) async throws {
+        let nowISO = ISO8601DateFormatter.shared.string(from: Date())
+        try await writer.write { db in
+            try db.execute(
+                sql: """
+                UPDATE release_subscriptions
+                SET notify_enabled = ?, modified_at = ?
+                WHERE repo_id = ?
+                """,
+                arguments: [enabled ? 1 : 0, nowISO, repoId]
+            )
+        }
+    }
+
+    func updatePollCursor(
+        repoId: Int64,
+        latestReleaseId: Int64?,
+        latestTagName: String?,
+        polledAt: Date
+    ) async throws {
+        let polledISO = ISO8601DateFormatter.shared.string(from: polledAt)
+        let nowISO = ISO8601DateFormatter.shared.string(from: Date())
+        try await writer.write { db in
+            try db.execute(
+                sql: """
+                UPDATE release_subscriptions
+                SET last_known_release_id = ?,
+                    last_known_tag_name = ?,
+                    last_polled_at = ?,
+                    modified_at = ?
+                WHERE repo_id = ?
+                """,
+                arguments: [latestReleaseId, latestTagName, polledISO, nowISO, repoId]
+            )
+        }
+    }
+}

--- a/Starcat/Core/Sync/ReleaseSubscriptionRepositoryProtocol.swift
+++ b/Starcat/Core/Sync/ReleaseSubscriptionRepositoryProtocol.swift
@@ -1,0 +1,45 @@
+//
+//  ReleaseSubscriptionRepositoryProtocol.swift
+//  Starcat
+//
+//  Release 订阅 Repository 协议（HOM-47）。
+//
+//  设计约束：
+//  - 一个 repo 至多一条订阅记录（repo_id 主键）
+//  - subscribe / unsubscribe 是显式操作；取消订阅时**不删行**只置 isSubscribed=false，
+//    便于二次订阅恢复 lastKnownReleaseId 游标，不会重新推送一遍历史 Release
+//  - 后台轮询通过 fetchActive() 一次拉所有"激活订阅"，避免 N+1
+//
+
+import Foundation
+
+protocol ReleaseSubscriptionRepositoryProtocol: Sendable {
+
+    // MARK: - 查询
+
+    /// 找该 repo 的订阅记录；从未订阅返回 nil。
+    func find(repoId: Int64) async throws -> ReleaseSubscription?
+
+    /// 拉取所有当前激活（is_subscribed=1）的订阅记录。
+    /// 后台轮询用：一次拉全 → 逐个查 GitHub Release → 更新游标。
+    func fetchActive() async throws -> [ReleaseSubscription]
+
+    /// 拉取所有订阅记录（含已取消订阅），用于时间线视图聚合 repo 信息。
+    func fetchAll() async throws -> [ReleaseSubscription]
+
+    // MARK: - 写入
+
+    /// 订阅。如已存在记录（isSubscribed=false），将其翻为 true 并更新 modifiedAt。
+    /// - Parameter primingReleaseId: 首次订阅时立即把 lastKnownReleaseId 写成"当前最新"，
+    ///   避免触发"补发历史 Release 通知"。
+    func subscribe(repoId: Int64, primingReleaseId: Int64?, primingTagName: String?) async throws
+
+    /// 取消订阅（is_subscribed=0），保留行 + 游标。
+    func unsubscribe(repoId: Int64) async throws
+
+    /// 仅切换 notify_enabled。订阅记录不存在时为 no-op（防御性）。
+    func setNotifyEnabled(repoId: Int64, enabled: Bool) async throws
+
+    /// 更新轮询游标（lastKnownReleaseId / lastKnownTagName / lastPolledAt）。
+    func updatePollCursor(repoId: Int64, latestReleaseId: Int64?, latestTagName: String?, polledAt: Date) async throws
+}

--- a/Starcat/Core/Sync/RepoRepository.swift
+++ b/Starcat/Core/Sync/RepoRepository.swift
@@ -159,6 +159,13 @@ struct GRDBRepoRepository {
         }
     }
 
+    /// HOM-47：按 GitHub repo id 找单条记录（含 is_starred=0 的"曾经 star 过"行）。
+    func findById(_ repoId: Int64) async throws -> Repo? {
+        try await writer.read { db in
+            try Repo.fetchOne(db, key: repoId)
+        }
+    }
+
     /// 未打标签的 repo（Sidebar "Untagged" 入口）。
     /// 实现：左联 repo_tags 找出无关联记录的 repos。
     func fetchUntagged() async throws -> [Repo] {

--- a/Starcat/Core/Sync/RepoRepositoryProtocol.swift
+++ b/Starcat/Core/Sync/RepoRepositoryProtocol.swift
@@ -50,6 +50,10 @@ protocol RepoRepositoryProtocol: Sendable {
     /// 全部已 star 的 repo（按 starred_at 倒序）。
     func fetchAllStarred() async throws -> [Repo]
 
+    /// 按 GitHub repo id 查找。HOM-47 ReleaseMonitor 巡检每个订阅时需要拿 owner/name。
+    /// 不存在返回 nil（不抛错），调用方决定后续行为（如跳过该次巡检）。
+    func findById(_ repoId: Int64) async throws -> Repo?
+
     /// 未打标签的 repo。
     func fetchUntagged() async throws -> [Repo]
 

--- a/Starcat/Features/Home/HomeView.swift
+++ b/Starcat/Features/Home/HomeView.swift
@@ -39,6 +39,11 @@ struct HomeView: View {
     @Environment(AuthSession.self) private var authSession
     @Environment(SyncManager.self) private var syncManager
     @Environment(AppSettings.self) private var settings
+    /// HOM-47：拿到 ReleasePoller 启动后台调度。
+    @Environment(AppDependencies.self) private var dependencies
+
+    /// HOM-47：Release 时间线 sheet 显示状态。
+    @State private var showReleaseTimeline: Bool = false
 
     /// HomeViewModel 在 HomeView 内部持有；用 @State 让生命周期与该视图绑定。
     /// AppDependencies 不构造它，因为 ViewModel 是 view-scoped，没必要塞进全局容器。
@@ -131,6 +136,7 @@ struct HomeView: View {
                 selectedPage: $selectedSidebarPage,
                 selectedTrendingLanguage: $selectedTrendingLanguage,
                 showTagManagement: $showTagManagement,
+                showReleaseTimeline: $showReleaseTimeline,
                 // 2026-06-02 21:38：透传给 SidebarHeaderView 让头像背景的语言色在 Trending 页也能联动
                 currentTrendingRepo: selectedTrendingRepo
             )
@@ -169,6 +175,21 @@ struct HomeView: View {
             }
         }) {
             TagManagementView(viewModel: tagMgmtVM)
+        }
+        // HOM-47：Release 时间线 sheet（独立窗口承载，不污染三栏布局）
+        .sheet(isPresented: $showReleaseTimeline) {
+            ReleaseTimelineView()
+                .environment(dependencies)
+        }
+        // HOM-47：登录后启动后台 Release 轮询；登出时停。
+        // 与 SyncManager 不同：Release Poller 自调度（NSBackgroundActivityScheduler），
+        // 启动一次后由系统在后台触发；这里只负责启停门控。
+        .onChange(of: authSession.state) { _, newState in
+            if newState.isAuthenticated {
+                dependencies.releasePoller.start()
+            } else {
+                dependencies.releasePoller.stop()
+            }
         }
         .task {
             // 启动 / 重新进入 HomeView 时默认回三栏展开。运行期用户手动缩窗时，

--- a/Starcat/Features/Home/RepoDetailView.swift
+++ b/Starcat/Features/Home/RepoDetailView.swift
@@ -338,6 +338,8 @@ struct RepoDetailView: View {
             RepoTagsSection(repo: repo)
             // W4 A4：私有笔记 + 状态段
             RepoNotesSection(repo: repo)
+            // HOM-47：Release 订阅段（订阅按钮 + 最新版本一行）
+            RepoReleaseSection(repo: repo)
         }
         .padding(.horizontal, 24)
         .padding(.top, 16)

--- a/Starcat/Features/Home/SidebarView.swift
+++ b/Starcat/Features/Home/SidebarView.swift
@@ -31,6 +31,8 @@ struct SidebarView: View {
     @Binding var selectedPage: SidebarRootPage
     @Binding var selectedTrendingLanguage: TrendingLanguage
     @Binding var showTagManagement: Bool
+    /// HOM-47：触发 Release 时间线 sheet。
+    @Binding var showReleaseTimeline: Bool
 
     /// 当前在 Trending 页面选中的 repo，仅用于透传给 `SidebarHeaderView` 让头像背景的
     /// 语言色在 Trending 页也能联动（2026-06-02 21:38 接入）。Manage 页面应为 nil。
@@ -96,6 +98,8 @@ struct SidebarView: View {
             Section("sidebar.mainNavigation") {
                 row(.allStars, count: viewModel.totalCount)
                 row(.untagged, count: viewModel.untaggedCount)
+                // HOM-47：Release 时间线入口（独立 sheet 承载，避免与三栏导航 selection 冲突）
+                releaseTimelineRow
             }
 
             // W4 A6：Tags 段。
@@ -414,6 +418,30 @@ struct SidebarView: View {
                 }
             }
         }
+    }
+
+    /// HOM-47：Release 时间线入口行。
+    ///
+    /// 设计取舍：把入口放在 Manage 的"主导航"段而不是单独的根页（`SidebarRootPage`），
+    /// 是因为 Release 时间线属于 Stars 数据的衍生视图，跟 All Stars / Untagged 同源；
+    /// 用 `Button` + sheet 而不是 `selection` 行，避免插入新 case 牵动 HomeViewModel
+    /// reload 路径。
+    @ViewBuilder
+    private var releaseTimelineRow: some View {
+        Button {
+            showReleaseTimeline = true
+        } label: {
+            Label {
+                Text("sidebar.releaseTimeline")
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } icon: {
+                Image(systemName: "shippingbox.fill")
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .focusEffectDisabled()
     }
 
     /// W4 A6：tag 专属行——

--- a/Starcat/Features/Releases/ReleaseTimelineView.swift
+++ b/Starcat/Features/Releases/ReleaseTimelineView.swift
@@ -1,0 +1,450 @@
+//
+//  ReleaseTimelineView.swift
+//  Starcat
+//
+//  Release 订阅时间线视图（HOM-47）。
+//
+//  组件结构：
+//  - `ReleaseTimelineView` (View)：sheet / 独立窗口的根视图
+//  - `ReleaseTimelineViewModel` (@MainActor @Observable)：数据加载 / 已读切换 / 立即刷新
+//  - `ReleaseTimelineRow` (View)：单条 release 行 + 资产展开
+//  - `ReleaseAssetRow` (View)：单个资产 + 复制下载链接 + 平台 / 类型过滤已通过 ViewModel 传入的 query 处理
+//
+//  设计目标：
+//  - 独立路径展示所有订阅的 Release，不复用 RepoListView 的复杂状态机
+//  - 已读 / 未读切换 + "全部已读" 一键操作
+//  - 资产过滤：按文件名 / 平台关键字过滤；UI 简单地用一个 TextField + 下拉
+//  - 复制下载链接：按钮 → NSPasteboard
+//
+
+import SwiftUI
+import AppKit
+
+struct ReleaseTimelineView: View {
+
+    @Environment(AppDependencies.self) private var dependencies
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var viewModel: ReleaseTimelineViewModel?
+    @State private var copyToast: String?
+
+    /// 资产过滤关键字（空 = 不过滤）。
+    @State private var assetFilter: String = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+        .frame(minWidth: 720, minHeight: 520)
+        .frame(idealWidth: 880, idealHeight: 640)
+        .task {
+            if viewModel == nil {
+                viewModel = ReleaseTimelineViewModel(
+                    subscriptionRepository: dependencies.releaseSubscriptionRepository,
+                    releaseRepository: dependencies.releaseRepository,
+                    poller: dependencies.releasePoller
+                )
+            }
+            await viewModel?.reload()
+        }
+        .overlay(alignment: .bottom) {
+            if let toast = copyToast {
+                Text(toast)
+                    .font(.caption)
+                    .padding(.horizontal, 12).padding(.vertical, 6)
+                    .background(.regularMaterial, in: Capsule())
+                    .padding(.bottom, 16)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Label("releases.timeline.title", systemImage: "clock.arrow.circlepath")
+                .font(.headline)
+            if let vm = viewModel, vm.unreadCount > 0 {
+                Text(verbatim: "\(vm.unreadCount)")
+                    .font(.caption)
+                    .padding(.horizontal, 6).padding(.vertical, 2)
+                    .background(Color.accentColor.opacity(0.18), in: Capsule())
+                    .foregroundStyle(Color.accentColor)
+            }
+            Spacer()
+            assetFilterField
+            Button {
+                Task { await viewModel?.checkNow() }
+            } label: {
+                Label("releases.timeline.checkNow", systemImage: "arrow.clockwise")
+                    .font(.caption)
+            }
+            .buttonStyle(.borderless)
+            .focusEffectDisabled()
+            .disabled(viewModel?.isChecking == true)
+            Button {
+                Task { await viewModel?.markAllRead() }
+            } label: {
+                Label("releases.timeline.markAllRead", systemImage: "checkmark.circle")
+                    .font(.caption)
+            }
+            .buttonStyle(.borderless)
+            .focusEffectDisabled()
+            .disabled(viewModel?.entries.isEmpty == true)
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .focusEffectDisabled()
+            .help("general.close")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var assetFilterField: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .foregroundStyle(.secondary)
+                .font(.caption)
+            TextField("releases.assetFilter.placeholder", text: $assetFilter)
+                .textFieldStyle(.plain)
+                .frame(width: 160)
+                .font(.caption)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.bar, in: RoundedRectangle(cornerRadius: 6))
+        .help("releases.assetFilter.help")
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if let vm = viewModel {
+            if vm.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if vm.entries.isEmpty {
+                emptyState
+            } else {
+                List {
+                    ForEach(vm.entries) { entry in
+                        ReleaseTimelineRow(
+                            entry: entry,
+                            assetFilter: assetFilter,
+                            onToggleRead: { isRead in
+                                Task { await vm.markRead(entry: entry, isRead: isRead) }
+                            },
+                            onCopyAsset: { url in
+                                copyToPasteboard(url)
+                            }
+                        )
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "shippingbox")
+                .font(.system(size: 40))
+                .foregroundStyle(.tertiary)
+            Text("releases.timeline.empty.title")
+                .font(.headline)
+            Text("releases.timeline.empty.subtitle")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Helpers
+
+    private func copyToPasteboard(_ url: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(url, forType: .string)
+        withAnimation(.easeOut(duration: 0.18)) {
+            copyToast = String(localized: "releases.assetCopied")
+        }
+        Task {
+            try? await Task.sleep(for: .seconds(1.5))
+            withAnimation(.easeOut(duration: 0.18)) {
+                copyToast = nil
+            }
+        }
+    }
+}
+
+// MARK: - ViewModel
+
+@MainActor
+@Observable
+final class ReleaseTimelineViewModel {
+
+    private(set) var entries: [ReleaseTimelineEntry] = []
+    private(set) var unreadCount: Int = 0
+    private(set) var isLoading: Bool = false
+    private(set) var isChecking: Bool = false
+    private(set) var errorMessage: String?
+
+    private let subscriptionRepository: any ReleaseSubscriptionRepositoryProtocol
+    private let releaseRepository: any ReleaseRepositoryProtocol
+    private let poller: ReleasePoller
+
+    init(
+        subscriptionRepository: any ReleaseSubscriptionRepositoryProtocol,
+        releaseRepository: any ReleaseRepositoryProtocol,
+        poller: ReleasePoller
+    ) {
+        self.subscriptionRepository = subscriptionRepository
+        self.releaseRepository = releaseRepository
+        self.poller = poller
+    }
+
+    func reload() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            async let entriesTask = releaseRepository.fetchTimeline(limit: 200)
+            async let countTask = releaseRepository.unreadCount()
+            entries = try await entriesTask
+            unreadCount = try await countTask
+            errorMessage = nil
+        } catch {
+            errorMessage = String(localized: "releases.timeline.error.loadFailed")
+        }
+    }
+
+    /// 立即触发一次轮询；UI 期间显示 spinner，完成后重 reload。
+    func checkNow() async {
+        isChecking = true
+        defer { isChecking = false }
+        _ = await poller.runNow()
+        await reload()
+    }
+
+    func markRead(entry: ReleaseTimelineEntry, isRead: Bool) async {
+        do {
+            try await releaseRepository.markRead(releaseId: entry.release.id, isRead: isRead)
+            await reload()
+        } catch {
+            errorMessage = String(localized: "releases.timeline.error.markReadFailed")
+        }
+    }
+
+    func markAllRead() async {
+        do {
+            try await releaseRepository.markAllRead()
+            await reload()
+        } catch {
+            errorMessage = String(localized: "releases.timeline.error.markAllReadFailed")
+        }
+    }
+}
+
+// MARK: - Row
+
+private struct ReleaseTimelineRow: View {
+
+    let entry: ReleaseTimelineEntry
+    let assetFilter: String
+    let onToggleRead: (Bool) -> Void
+    let onCopyAsset: (String) -> Void
+
+    @State private var isExpanded: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                // 未读 / 已读圆点
+                Circle()
+                    .fill(entry.release.isRead ? Color.clear : Color.accentColor)
+                    .frame(width: 8, height: 8)
+
+                // repo 名称
+                Text(verbatim: entry.repo.fullName)
+                    .font(.subheadline.weight(.medium))
+
+                // tag
+                Text(verbatim: entry.release.tagName)
+                    .font(.caption.monospaced())
+                    .padding(.horizontal, 6).padding(.vertical, 1)
+                    .background(.bar, in: Capsule())
+
+                if entry.release.isPrerelease {
+                    Text("releases.row.prerelease")
+                        .font(.caption2)
+                        .padding(.horizontal, 5).padding(.vertical, 1)
+                        .background(Color.orange.opacity(0.18), in: Capsule())
+                        .foregroundStyle(Color.orange)
+                }
+
+                Spacer()
+
+                if let date = relativeDate(entry.release.publishedAt) {
+                    Text(verbatim: date)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                Button {
+                    onToggleRead(!entry.release.isRead)
+                } label: {
+                    Image(systemName: entry.release.isRead ? "circle" : "checkmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(entry.release.isRead ? .secondary : Color.accentColor)
+                }
+                .buttonStyle(.borderless)
+                .focusEffectDisabled()
+                .help(entry.release.isRead ? Text("releases.row.markUnread") : Text("releases.row.markRead"))
+
+                Button {
+                    if let url = URL(string: entry.release.htmlUrl) {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    Image(systemName: "arrow.up.right.square")
+                        .font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .focusEffectDisabled()
+                .help("releases.openOnGitHub")
+            }
+
+            if let title = entry.release.name, !title.isEmpty, title != entry.release.tagName {
+                Text(verbatim: title)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+            }
+
+            if let body = entry.release.bodyTruncated, !body.isEmpty {
+                Text(verbatim: body)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(isExpanded ? nil : 3)
+            }
+
+            assetsSection
+        }
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation(.easeInOut(duration: 0.18)) {
+                isExpanded.toggle()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var assetsSection: some View {
+        let assets = filteredAssets
+        if !assets.isEmpty {
+            DisclosureGroup(isExpanded: $isExpanded) {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(assets) { asset in
+                        ReleaseAssetRow(asset: asset, onCopy: onCopyAsset)
+                    }
+                }
+                .padding(.top, 4)
+            } label: {
+                Text(String(format: String(localized: "releases.row.assetsCountFormat"), assets.count))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .disclosureGroupStyle(.automatic)
+        } else if !assetFilter.isEmpty {
+            // 用户在过滤但本条没匹配资产，给一个占位提示
+            Text("releases.row.noMatchingAsset")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    private var filteredAssets: [ReleaseAsset] {
+        let assets = ReleaseAssetCodec.decode(entry.release.assetsJson)
+        let q = assetFilter.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !q.isEmpty else { return assets }
+        return assets.filter { asset in
+            asset.name.lowercased().contains(q) ||
+            (asset.contentType?.lowercased().contains(q) ?? false)
+        }
+    }
+
+    private func relativeDate(_ iso: String?) -> String? {
+        guard let iso, let date = ISO8601DateFormatter.shared.date(from: iso) else { return nil }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}
+
+// MARK: - AssetRow
+
+private struct ReleaseAssetRow: View {
+    let asset: ReleaseAsset
+    let onCopy: (String) -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: assetIcon)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+                .frame(width: 16)
+            Text(verbatim: asset.name)
+                .font(.caption)
+                .lineLimit(1)
+            Spacer()
+            Text(verbatim: ByteCountFormatter.string(fromByteCount: Int64(asset.size), countStyle: .file))
+                .font(.caption2.monospaced())
+                .foregroundStyle(.tertiary)
+            Button {
+                onCopy(asset.browserDownloadUrl)
+            } label: {
+                Label("releases.copyDownloadLink", systemImage: "doc.on.clipboard")
+                    .font(.caption2)
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.borderless)
+            .focusEffectDisabled()
+            .help("releases.copyDownloadLink")
+            Button {
+                if let url = URL(string: asset.browserDownloadUrl) {
+                    NSWorkspace.shared.open(url)
+                }
+            } label: {
+                Label("releases.downloadAsset", systemImage: "arrow.down.circle")
+                    .font(.caption2)
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.borderless)
+            .focusEffectDisabled()
+            .help("releases.downloadAsset")
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+    }
+
+    /// 按文件扩展名 / contentType 给个有视觉区分度的图标。
+    /// 没有命中规则就回退默认 `doc`，避免 UI 突兀。
+    private var assetIcon: String {
+        let lower = asset.name.lowercased()
+        if lower.hasSuffix(".dmg") { return "internaldrive" }
+        if lower.hasSuffix(".pkg") { return "shippingbox.fill" }
+        if lower.hasSuffix(".zip") || lower.hasSuffix(".tar.gz") || lower.hasSuffix(".tgz") { return "doc.zipper" }
+        if lower.hasSuffix(".exe") || lower.hasSuffix(".msi") { return "pc" }
+        if lower.hasSuffix(".deb") || lower.hasSuffix(".rpm") || lower.hasSuffix(".appimage") { return "terminal" }
+        if lower.hasSuffix(".app") { return "macwindow" }
+        return "doc"
+    }
+}

--- a/Starcat/Features/Releases/ReleaseTimelineView.swift
+++ b/Starcat/Features/Releases/ReleaseTimelineView.swift
@@ -37,8 +37,10 @@ struct ReleaseTimelineView: View {
             Divider()
             content
         }
-        .frame(minWidth: 720, minHeight: 520)
-        .frame(idealWidth: 880, idealHeight: 640)
+        // 2026-06-04 dong4j 反馈：宽度减小 1/3 —— 原 720/880 → 480/587。
+        // sheet 是非主交互窗口，更窄能配合 macOS 多窗口布局把屏幕让给主窗口。
+        .frame(minWidth: 480, minHeight: 520)
+        .frame(idealWidth: 587, idealHeight: 640)
         .task {
             if viewModel == nil {
                 viewModel = ReleaseTimelineViewModel(
@@ -76,15 +78,12 @@ struct ReleaseTimelineView: View {
             }
             Spacer()
             assetFilterField
-            Button {
+            // 立即检查：图标与 SidebarSyncButton（"全部仓库"右侧刷新图标）保持一致——
+            // `arrow.triangle.2.circlepath` + 进行中线性 1s repeatForever 转圈，
+            // dong4j 反馈"图标也要保持统一"。
+            ReleaseCheckNowButton(isChecking: viewModel?.isChecking == true) {
                 Task { await viewModel?.checkNow() }
-            } label: {
-                Label("releases.timeline.checkNow", systemImage: "arrow.clockwise")
-                    .font(.caption)
             }
-            .buttonStyle(.borderless)
-            .focusEffectDisabled()
-            .disabled(viewModel?.isChecking == true)
             Button {
                 Task { await viewModel?.markAllRead() }
             } label: {
@@ -181,6 +180,57 @@ struct ReleaseTimelineView: View {
             try? await Task.sleep(for: .seconds(1.5))
             withAnimation(.easeOut(duration: 0.18)) {
                 copyToast = nil
+            }
+        }
+    }
+}
+
+// MARK: - 立即检查按钮
+
+/// 与 `SidebarSyncButton`（"全部仓库"右侧刷新图标）视觉一致的立即检查按钮：
+/// `arrow.triangle.2.circlepath` 图标，进行中时线性 1s repeatForever 旋转，
+/// 完成后 0.2s easeOut 回正。dong4j 反馈刷新类按钮在 App 内必须图标 + 动效统一，
+/// 否则用户在不同界面看到不同 spinner 形态会产生认知负担。
+private struct ReleaseCheckNowButton: View {
+
+    let isChecking: Bool
+    let action: () -> Void
+
+    /// 用 `@State` 单独追踪 rotation，配 `withAnimation` repeatForever 才能保持
+    /// 转圈顺滑——直接对 `isChecking` 做 .rotationEffect 动画在状态切换瞬间会跳。
+    @State private var rotation: Double = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        Button(action: action) {
+            Label {
+                Text("releases.timeline.checkNow").font(.caption)
+            } icon: {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .rotationEffect(.degrees(rotation))
+            }
+            .font(.caption)
+        }
+        .buttonStyle(.borderless)
+        .focusEffectDisabled()
+        .disabled(isChecking)
+        .onAppear { updateRotation(isChecking: isChecking) }
+        .onChange(of: isChecking) { _, newValue in
+            updateRotation(isChecking: newValue)
+        }
+    }
+
+    /// 与 `SidebarSyncButton.updateRotation` 同款：进行中无限转，完成后回正。
+    /// reduceMotion 时跳过 repeatForever（保留可访问性）。
+    private func updateRotation(isChecking: Bool) {
+        if isChecking {
+            if reduceMotion { return }
+            withAnimation(.linear(duration: 1).repeatForever(autoreverses: false)) {
+                rotation = 360
+            }
+        } else {
+            withAnimation(.easeOut(duration: 0.2)) {
+                rotation = 0
             }
         }
     }

--- a/Starcat/Features/Releases/ReleaseTimelineView.swift
+++ b/Starcat/Features/Releases/ReleaseTimelineView.swift
@@ -316,15 +316,27 @@ private struct ReleaseTimelineRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
+            // 仓库标识行（dong4j 反馈：原版没显示头像 + 字号偏小看不清是哪个仓库）
+            // 改造：加 22pt 圆形头像 + repo 名称从 subheadline 升到 body.semibold，
+            // 视觉权重接近 RepoRowView 的 compact 模式，保证用户在时间线扫读时
+            // 能优先识别"这是哪个仓库的发布"。
             HStack(spacing: 8) {
-                // 未读 / 已读圆点
+                // 未读 / 已读圆点（保持最左侧的状态指示位置不变）
                 Circle()
                     .fill(entry.release.isRead ? Color.clear : Color.accentColor)
                     .frame(width: 8, height: 8)
 
-                // repo 名称
+                // 仓库头像（22pt 与 RepoRowView compact 行一致；不描边避免视觉嘈杂）
+                RemoteAvatar(
+                    urlString: RepoAvatarURL.from(owner: entry.repo.owner),
+                    size: 22,
+                    showBorder: false
+                )
+
+                // repo 名称：升到 body.semibold，比 tag / 时间这些副信息明显大一档
                 Text(verbatim: entry.repo.fullName)
-                    .font(.subheadline.weight(.medium))
+                    .font(.body.weight(.semibold))
+                    .lineLimit(1)
 
                 // tag
                 Text(verbatim: entry.release.tagName)

--- a/Starcat/Features/Releases/RepoReleaseSection.swift
+++ b/Starcat/Features/Releases/RepoReleaseSection.swift
@@ -1,0 +1,306 @@
+//
+//  RepoReleaseSection.swift
+//  Starcat
+//
+//  Repo 详情页 - Release 订阅段（HOM-47）。
+//
+//  组件结构：
+//  - `RepoReleaseSection` (View)：展示订阅状态 + 最新 Release 概要 + 订阅 / 通知开关
+//  - `RepoReleaseSectionViewModel` (@MainActor @Observable)：状态机 + 副作用入口
+//
+//  设计取舍：
+//  - 订阅按钮的"首次按下"会立即拉一次 Release（priming 游标），
+//    避免用户后续轮询时被推送一堆历史 Release
+//  - 详情页只展示最新一条；完整历史去时间线视图查
+//  - 通知开关与订阅状态解耦：用户可"订阅但静默"（默认开启）
+//
+
+import SwiftUI
+
+struct RepoReleaseSection: View {
+
+    let repo: Repo
+
+    @Environment(AppDependencies.self) private var dependencies
+
+    @State private var viewModel: RepoReleaseSectionViewModel?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Label("releases.section.title", systemImage: "shippingbox")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                if let vm = viewModel {
+                    if vm.isLoading {
+                        ProgressView()
+                            .controlSize(.mini)
+                    }
+                    subscribeButton(vm: vm)
+                    if vm.subscription?.isSubscribed == true {
+                        notifyToggle(vm: vm)
+                    }
+                }
+            }
+
+            latestReleaseRow
+        }
+        .task(id: repo.id) {
+            if viewModel == nil {
+                viewModel = RepoReleaseSectionViewModel(
+                    apiClient: dependencies.apiClient,
+                    subscriptionRepository: dependencies.releaseSubscriptionRepository,
+                    releaseRepository: dependencies.releaseRepository,
+                    notificationService: dependencies.releaseNotificationService
+                )
+            }
+            await viewModel?.loadFor(repo: repo)
+        }
+    }
+
+    @ViewBuilder
+    private var latestReleaseRow: some View {
+        if let vm = viewModel, let latest = vm.latestRelease {
+            HStack(spacing: 8) {
+                Image(systemName: "tag.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(verbatim: latest.tagName)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                if let date = relativeDate(latest.publishedAt) {
+                    Text("·")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                    Text(verbatim: date)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Button {
+                    if let url = URL(string: latest.htmlUrl) {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    Image(systemName: "arrow.up.right.square")
+                        .font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .focusEffectDisabled()
+                .help("releases.openOnGitHub")
+            }
+        } else if let vm = viewModel, vm.errorMessage != nil {
+            Text(vm.errorMessage ?? "")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        } else if viewModel?.isLoading == false {
+            Text("releases.section.noRelease")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    @ViewBuilder
+    private func subscribeButton(vm: RepoReleaseSectionViewModel) -> some View {
+        let subscribed = vm.subscription?.isSubscribed == true
+        Button {
+            Task {
+                if subscribed {
+                    await vm.unsubscribe(repoId: repo.id)
+                } else {
+                    await vm.subscribe(owner: repo.owner, repo: repo.name, repoId: repo.id)
+                }
+            }
+        } label: {
+            Label(
+                subscribed ? "releases.action.unsubscribe" : "releases.action.subscribe",
+                systemImage: subscribed ? "bell.slash" : "bell.badge"
+            )
+            .font(.caption)
+        }
+        .buttonStyle(.borderless)
+        .focusEffectDisabled()
+        .disabled(vm.isMutating)
+    }
+
+    @ViewBuilder
+    private func notifyToggle(vm: RepoReleaseSectionViewModel) -> some View {
+        let notifyOn = vm.subscription?.notifyEnabled == true
+        Button {
+            Task { await vm.setNotifyEnabled(repoId: repo.id, enabled: !notifyOn) }
+        } label: {
+            Image(systemName: notifyOn ? "bell.fill" : "bell.slash.fill")
+                .font(.caption)
+                .foregroundStyle(notifyOn ? Color.accentColor : .secondary)
+        }
+        .buttonStyle(.borderless)
+        .focusEffectDisabled()
+        .help(notifyOn ? Text("releases.notify.disable") : Text("releases.notify.enable"))
+    }
+
+    private func relativeDate(_ iso: String?) -> String? {
+        guard let iso, let date = ISO8601DateFormatter.shared.date(from: iso) else { return nil }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}
+
+// MARK: - ViewModel
+
+@MainActor
+@Observable
+final class RepoReleaseSectionViewModel {
+
+    private(set) var subscription: ReleaseSubscription?
+    private(set) var latestRelease: ReleaseRecord?
+    private(set) var isLoading: Bool = false
+    private(set) var isMutating: Bool = false
+    private(set) var errorMessage: String?
+
+    private let apiClient: any GitHubAPIClientProtocol
+    private let subscriptionRepository: any ReleaseSubscriptionRepositoryProtocol
+    private let releaseRepository: any ReleaseRepositoryProtocol
+    private let notificationService: ReleaseNotificationService
+
+    init(
+        apiClient: any GitHubAPIClientProtocol,
+        subscriptionRepository: any ReleaseSubscriptionRepositoryProtocol,
+        releaseRepository: any ReleaseRepositoryProtocol,
+        notificationService: ReleaseNotificationService
+    ) {
+        self.apiClient = apiClient
+        self.subscriptionRepository = subscriptionRepository
+        self.releaseRepository = releaseRepository
+        self.notificationService = notificationService
+    }
+
+    func loadFor(repo: Repo) async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            async let subTask = subscriptionRepository.find(repoId: repo.id)
+            async let latestTask = releaseRepository.latest(forRepo: repo.id)
+            self.subscription = try await subTask
+            self.latestRelease = try await latestTask
+            errorMessage = nil
+        } catch {
+            errorMessage = String(localized: "releases.error.loadFailed")
+        }
+    }
+
+    /// 订阅入口。
+    ///
+    /// 流程：
+    /// 1. 立即拉一页 Releases（priming）
+    /// 2. 把"当前最新"作为 lastKnownReleaseId 写库（避免下次轮询补推）
+    /// 3. 把所有 priming 拿到的 Release 写库 + 标记为 isRead=true（用户主动订阅，
+    ///    不需要把当前已存在的版本当成"未读"高亮）
+    /// 4. 异步请求通知授权（首次订阅触发系统对话框）
+    func subscribe(owner: String, repo repoName: String, repoId: Int64) async {
+        isMutating = true
+        defer { isMutating = false }
+        do {
+            let response = try await apiClient.releases(owner: owner, repo: repoName, perPage: 10)
+            let dtos = response.value
+            let nowISO = ISO8601DateFormatter.shared.string(from: Date())
+            let records = dtos.map { dto in
+                ReleaseRecord(
+                    id: dto.id,
+                    repoId: repoId,
+                    tagName: dto.tagName,
+                    name: dto.name,
+                    bodyTruncated: Self.truncateBody(dto.body),
+                    htmlUrl: dto.htmlUrl,
+                    isPrerelease: dto.prerelease,
+                    isDraft: dto.draft,
+                    publishedAt: dto.publishedAt,
+                    createdAtRemote: dto.createdAt,
+                    assetsJson: ReleaseAssetCodec.encode(dto.assets?.map(Self.dtoToAsset)),
+                    isRead: true,
+                    fetchedAt: nowISO
+                )
+            }
+
+            // priming：取最新 release id 作为游标
+            let primingId = dtos.first?.id
+            let primingTag = dtos.first?.tagName
+
+            try await subscriptionRepository.subscribe(repoId: repoId, primingReleaseId: primingId, primingTagName: primingTag)
+            try await releaseRepository.upsertMany(records, isReadDefault: true)
+
+            // 主动请求一次通知授权（首次订阅时弹系统对话框）
+            await notificationService.ensureAuthorized()
+
+            await loadFor(repo: makeRepoStub(id: repoId, owner: owner, name: repoName))
+        } catch NetworkError.notFound {
+            // 仓库无 Release：仍允许订阅（未来作者发布会被识别为新）
+            do {
+                try await subscriptionRepository.subscribe(repoId: repoId, primingReleaseId: nil, primingTagName: nil)
+                await notificationService.ensureAuthorized()
+                await loadFor(repo: makeRepoStub(id: repoId, owner: owner, name: repoName))
+            } catch {
+                errorMessage = String(localized: "releases.error.subscribeFailed")
+            }
+        } catch {
+            errorMessage = String(localized: "releases.error.subscribeFailed")
+        }
+    }
+
+    func unsubscribe(repoId: Int64) async {
+        isMutating = true
+        defer { isMutating = false }
+        do {
+            try await subscriptionRepository.unsubscribe(repoId: repoId)
+            // 重新读一次 → subscription.isSubscribed = false（行保留）
+            self.subscription = try await subscriptionRepository.find(repoId: repoId)
+        } catch {
+            errorMessage = String(localized: "releases.error.unsubscribeFailed")
+        }
+    }
+
+    func setNotifyEnabled(repoId: Int64, enabled: Bool) async {
+        isMutating = true
+        defer { isMutating = false }
+        do {
+            try await subscriptionRepository.setNotifyEnabled(repoId: repoId, enabled: enabled)
+            self.subscription = try await subscriptionRepository.find(repoId: repoId)
+        } catch {
+            errorMessage = String(localized: "releases.error.toggleNotifyFailed")
+        }
+    }
+
+    // MARK: - 工具
+
+    /// loadFor(repo:) 需要 Repo，但 unsubscribe 之后我们只持有 id。这里造一个 stub
+    /// 仅用于 task 的 id 一致性，不参与展示路径。
+    private func makeRepoStub(id: Int64, owner: String, name: String) -> Repo {
+        Repo(
+            id: id, owner: owner, name: name, fullName: "\(owner)/\(name)",
+            description: nil, language: nil, starsCount: 0, forksCount: 0, watchersCount: 0,
+            topics: nil, license: nil, homepage: nil, htmlUrl: "", cloneUrl: nil, sshUrl: nil,
+            isPrivate: false, isFork: false, isArchived: false, isStarred: true,
+            pushedAt: nil, createdAt: nil, updatedAt: nil, starredAt: nil, cachedAt: nil
+        )
+    }
+
+    private static func truncateBody(_ body: String?) -> String? {
+        guard let body, !body.isEmpty else { return nil }
+        let limit = 600
+        return body.count <= limit ? body : String(body.prefix(limit))
+    }
+
+    private static func dtoToAsset(_ dto: GitHubReleaseAssetDTO) -> ReleaseAsset {
+        ReleaseAsset(
+            id: dto.id,
+            name: dto.name,
+            contentType: dto.contentType,
+            size: dto.size,
+            browserDownloadUrl: dto.browserDownloadUrl,
+            downloadCount: dto.downloadCount,
+            createdAt: dto.createdAt
+        )
+    }
+}

--- a/Starcat/Features/Releases/RepoReleaseSection.swift
+++ b/Starcat/Features/Releases/RepoReleaseSection.swift
@@ -27,10 +27,18 @@ struct RepoReleaseSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
+            // 标题行：与 Tags / Notes 段保持一致——
+            // "Releases" Title 后面紧贴 Subscribe / Unsubscribe 按钮（不右对齐），
+            // 通知静默开关与右端 ProgressView 用 Spacer 推到行尾，
+            // 让"添加 / 修改"类的主操作（订阅）始终贴在 label 旁边。
             HStack(spacing: 8) {
                 Label("releases.section.title", systemImage: "shippingbox")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                if let vm = viewModel {
+                    subscribeButton(vm: vm)
+                }
 
                 Spacer()
 
@@ -39,7 +47,6 @@ struct RepoReleaseSection: View {
                         ProgressView()
                             .controlSize(.mini)
                     }
-                    subscribeButton(vm: vm)
                     if vm.subscription?.isSubscribed == true {
                         notifyToggle(vm: vm)
                     }
@@ -68,9 +75,23 @@ struct RepoReleaseSection: View {
                 Image(systemName: "tag.fill")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
-                Text(verbatim: latest.tagName)
-                    .font(.caption)
-                    .fontWeight(.medium)
+                // tag 本身就是跳转入口：蓝色 accent 颜色暗示可点击，配 `.pressableHover()`
+                // 与 Stars / Forks 等 Stat Item 一致的 opacity + scale 反馈，
+                // 替代原先额外的 `arrow.up.right.square` 跳转图标按钮（dong4j 反馈交互冗余）。
+                Button {
+                    if let url = URL(string: latest.htmlUrl) {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    Text(verbatim: latest.tagName)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(Color.accentColor)
+                }
+                .buttonStyle(.plain)
+                .focusEffectDisabled()
+                .pressableHover()
+                .help("releases.openOnGitHub")
                 if let date = relativeDate(latest.publishedAt) {
                     Text("·")
                         .font(.caption)
@@ -79,17 +100,6 @@ struct RepoReleaseSection: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-                Button {
-                    if let url = URL(string: latest.htmlUrl) {
-                        NSWorkspace.shared.open(url)
-                    }
-                } label: {
-                    Image(systemName: "arrow.up.right.square")
-                        .font(.caption)
-                }
-                .buttonStyle(.borderless)
-                .focusEffectDisabled()
-                .help("releases.openOnGitHub")
             }
         } else if let vm = viewModel, vm.errorMessage != nil {
             Text(vm.errorMessage ?? "")

--- a/Starcat/Resources/Localizable.xcstrings
+++ b/Starcat/Resources/Localizable.xcstrings
@@ -3268,6 +3268,22 @@
         }
       }
     },
+    "general.close" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
+          }
+        }
+      }
+    },
     "general.ok" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -3937,6 +3953,470 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查看仓库详情需要登录 GitHub 账号"
+          }
+        }
+      }
+    },
+    "releases.action.subscribe" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subscribe"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "订阅"
+          }
+        }
+      }
+    },
+    "releases.action.unsubscribe" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unsubscribe"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消订阅"
+          }
+        }
+      }
+    },
+    "releases.assetCopied" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download link copied"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载链接已复制"
+          }
+        }
+      }
+    },
+    "releases.assetFilter.help" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter assets by file name or content type, e.g. dmg / arm64 / linux"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按文件名或类型过滤资产，例如 dmg / arm64 / linux"
+          }
+        }
+      }
+    },
+    "releases.assetFilter.placeholder" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter assets…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "过滤资产…"
+          }
+        }
+      }
+    },
+    "releases.copyDownloadLink" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy download link"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制下载链接"
+          }
+        }
+      }
+    },
+    "releases.downloadAsset" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open download in browser"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在浏览器中打开下载"
+          }
+        }
+      }
+    },
+    "releases.error.loadFailed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to load release info"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加载发布信息失败"
+          }
+        }
+      }
+    },
+    "releases.error.subscribeFailed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subscribe failed"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "订阅失败"
+          }
+        }
+      }
+    },
+    "releases.error.toggleNotifyFailed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to toggle notifications"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换通知开关失败"
+          }
+        }
+      }
+    },
+    "releases.error.unsubscribeFailed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unsubscribe failed"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消订阅失败"
+          }
+        }
+      }
+    },
+    "releases.notify.disable" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mute new release notifications"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "静默新版本通知"
+          }
+        }
+      }
+    },
+    "releases.notify.enable" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable new release notifications"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用新版本通知"
+          }
+        }
+      }
+    },
+    "releases.openOnGitHub" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open on GitHub"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 上打开"
+          }
+        }
+      }
+    },
+    "releases.row.assetsCountFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d assets"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "资产 %d 个"
+          }
+        }
+      }
+    },
+    "releases.row.markRead" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark as read"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标记为已读"
+          }
+        }
+      }
+    },
+    "releases.row.markUnread" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark as unread"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标记为未读"
+          }
+        }
+      }
+    },
+    "releases.row.noMatchingAsset" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No assets match the filter"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无匹配资产"
+          }
+        }
+      }
+    },
+    "releases.row.prerelease" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pre-release"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预发布"
+          }
+        }
+      }
+    },
+    "releases.section.noRelease" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No release published yet"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂未发布版本"
+          }
+        }
+      }
+    },
+    "releases.section.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Releases"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Releases"
+          }
+        }
+      }
+    },
+    "releases.timeline.checkNow" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check now"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即检查"
+          }
+        }
+      }
+    },
+    "releases.timeline.empty.subtitle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subscribe to repositories' releases from the repo detail page to track new versions here."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在仓库详情页订阅 Release，新版本会汇总到这里"
+          }
+        }
+      }
+    },
+    "releases.timeline.empty.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No releases yet"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无 Release 记录"
+          }
+        }
+      }
+    },
+    "releases.timeline.error.loadFailed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to load timeline"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加载时间线失败"
+          }
+        }
+      }
+    },
+    "releases.timeline.error.markAllReadFailed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to mark all as read"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部已读失败"
+          }
+        }
+      }
+    },
+    "releases.timeline.error.markReadFailed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to update read state"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新已读状态失败"
+          }
+        }
+      }
+    },
+    "releases.timeline.markAllRead" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark all read"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部已读"
+          }
+        }
+      }
+    },
+    "releases.timeline.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Release Timeline"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Release 时间线"
           }
         }
       }
@@ -6023,6 +6503,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开 GitHub Starred 页面"
+          }
+        }
+      }
+    },
+    "sidebar.releaseTimeline" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Release Timeline"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Release 时间线"
           }
         }
       }

--- a/StarcatTests/MockGitHubAPIClient.swift
+++ b/StarcatTests/MockGitHubAPIClient.swift
@@ -42,11 +42,15 @@ final class MockGitHubAPIClient: GitHubAPIClientProtocol, @unchecked Sendable {
     var starHandler: ((_ owner: String, _ repo: String) async throws -> Void)?
     var getCurrentUserHandler: (() async throws -> GitHubUserDTO)?
     var readmeHTMLHandler: ((_ owner: String, _ repo: String, _ ifNoneMatch: String?, _ ifModifiedSince: String?) async throws -> BytesResponse)?
+    /// HOM-47：Releases API mock handler。
+    var releasesHandler: ((_ owner: String, _ repo: String, _ perPage: Int) async throws -> APIResponse<[GitHubReleaseDTO]>)?
 
     // MARK: - 调用记录（供断言用）
 
     private(set) var readmeHTMLCalls: [(owner: String, repo: String, ifNoneMatch: String?, ifModifiedSince: String?)] = []
     private(set) var starCalls: [(owner: String, repo: String)] = []
+    /// HOM-47：releases 调用日志，便于断言"是否拉过 / 拉了几次"。
+    private(set) var releasesCalls: [(owner: String, repo: String, perPage: Int)] = []
 
     // MARK: - Protocol conformance
 
@@ -103,6 +107,14 @@ final class MockGitHubAPIClient: GitHubAPIClientProtocol, @unchecked Sendable {
     }
 
     func deleteSubscription(owner: String, repo: String) async throws {
+    }
+
+    func releases(owner: String, repo: String, perPage: Int) async throws -> APIResponse<[GitHubReleaseDTO]> {
+        releasesCalls.append((owner, repo, perPage))
+        guard let handler = releasesHandler else {
+            fatalError("MockGitHubAPIClient.releasesHandler 未设置")
+        }
+        return try await handler(owner, repo, perPage)
     }
 }
 

--- a/StarcatTests/ReleaseMonitorTests.swift
+++ b/StarcatTests/ReleaseMonitorTests.swift
@@ -1,0 +1,227 @@
+//
+//  ReleaseMonitorTests.swift
+//  StarcatTests
+//
+//  HOM-47：ReleaseMonitor 单测。
+//
+//  覆盖：
+//  - 首次轮询：cursor=nil → 不计为新（priming 已在订阅时完成）
+//  - 第二次轮询：cursor 之后的 release 全部计为新，notifyEnabled=true 才进 notifications
+//  - notifyEnabled=false：仍写库 + 推进 cursor，但 notifications 空
+//  - 单 repo 失败不打断整体（404 / 网络错误均不抛 + 推进 lastPolledAt）
+//  - 数据一致性：游标推进后再轮询，相同 release 不会被重复识别为新
+//
+
+import Testing
+import Foundation
+import GRDB
+@testable import Starcat
+
+@Suite("ReleaseMonitor")
+struct ReleaseMonitorTests {
+
+    // MARK: - 工具：搭一套 in-memory 全栈
+
+    @MainActor
+    private struct Stack {
+        let mock: MockGitHubAPIClient
+        let monitor: ReleaseMonitor
+        let releaseRepo: GRDBReleaseRepository
+        let subRepo: GRDBReleaseSubscriptionRepository
+        let repoRepo: GRDBRepoRepository
+        let db: any DatabaseManaging
+    }
+
+    @MainActor
+    private func makeStack() throws -> Stack {
+        let db = try InMemoryDatabaseManager()
+        let mock = MockGitHubAPIClient()
+        let releaseRepo = GRDBReleaseRepository(database: db)
+        let subRepo = GRDBReleaseSubscriptionRepository(database: db)
+        let repoRepo = GRDBRepoRepository(database: db)
+        let monitor = ReleaseMonitor(
+            apiClient: mock,
+            subscriptionRepo: subRepo,
+            releaseRepo: releaseRepo,
+            repoRepo: repoRepo,
+            perPage: 10
+        )
+        return Stack(
+            mock: mock,
+            monitor: monitor,
+            releaseRepo: releaseRepo,
+            subRepo: subRepo,
+            repoRepo: repoRepo,
+            db: db
+        )
+    }
+
+    /// 构造一组 GitHub Releases DTO（默认 desc 排），便于覆盖游标递进逻辑。
+    private func makeDTOs(ids: [Int64]) -> [GitHubReleaseDTO] {
+        ids.map { id in
+            GitHubReleaseDTO(
+                id: id,
+                tagName: "v\(id)",
+                name: "Release v\(id)",
+                body: nil,
+                htmlUrl: "https://x/y/releases/tag/v\(id)",
+                prerelease: false,
+                draft: false,
+                publishedAt: "2026-06-\(String(format: "%02d", id))T00:00:00Z",
+                createdAt: "2026-06-\(String(format: "%02d", id))T00:00:00Z",
+                assets: nil
+            )
+        }
+    }
+
+    private func okResponse<T>(_ value: T) -> APIResponse<T> {
+        APIResponse(
+            value: value,
+            linkHeader: LinkHeader(nextPage: nil, lastPage: nil),
+            rateLimit: .empty,
+            statusCode: 200,
+            etag: nil
+        )
+    }
+
+    // MARK: - 测试
+
+    @Test("首次轮询：cursor 已 priming 至最新 → 无新 Release，不发通知")
+    @MainActor
+    func firstPollWithPrimingFindsNoNew() async throws {
+        let s = try makeStack()
+        try await s.db.insertRepoFixture(id: 42)
+        // 订阅时 priming 到最新 id=3
+        try await s.subRepo.subscribe(repoId: 42, primingReleaseId: 3, primingTagName: "v3")
+
+        s.mock.releasesHandler = { _, _, _ in
+            self.okResponse(self.makeDTOs(ids: [3, 2, 1]))
+        }
+
+        let report = await s.monitor.runOnce()
+        #expect(report.hasNewReleases == false)
+        #expect(report.notifications.isEmpty)
+        #expect(s.mock.releasesCalls.count == 1)
+        // 入库：3 条历史 release 已 upsert
+        let stored = try await s.releaseRepo.fetch(forRepo: 42, limit: 50)
+        #expect(stored.count == 3)
+    }
+
+    @Test("第二次轮询：cursor 之后新增 → notifications 命中且 notify_enabled=true")
+    @MainActor
+    func secondPollDetectsNewWithNotify() async throws {
+        let s = try makeStack()
+        try await s.db.insertRepoFixture(id: 42)
+        try await s.subRepo.subscribe(repoId: 42, primingReleaseId: 3, primingTagName: "v3")
+
+        // 先模拟一次空闲轮询不变：cursor 仍是 3
+        s.mock.releasesHandler = { _, _, _ in
+            self.okResponse(self.makeDTOs(ids: [5, 4, 3, 2, 1]))
+        }
+
+        let report = await s.monitor.runOnce()
+        #expect(report.newReleasesByRepo[42] == 2) // id 4 + 5
+        #expect(report.notifications.count == 2)
+        #expect(report.notifications.map(\.release.id).sorted() == [4, 5])
+
+        // 游标推进：再轮询一次，无新增
+        let report2 = await s.monitor.runOnce()
+        #expect(report2.hasNewReleases == false)
+        #expect(report2.notifications.isEmpty)
+
+        let updated = try #require(try await s.subRepo.find(repoId: 42))
+        #expect(updated.lastKnownReleaseId == 5)
+        #expect(updated.lastKnownTagName == "v5")
+    }
+
+    @Test("notifyEnabled=false：仍识别新 Release + 入库，但 notifications 空")
+    @MainActor
+    func newButSilent() async throws {
+        let s = try makeStack()
+        try await s.db.insertRepoFixture(id: 42)
+        try await s.subRepo.subscribe(repoId: 42, primingReleaseId: 1, primingTagName: "v1")
+        try await s.subRepo.setNotifyEnabled(repoId: 42, enabled: false)
+
+        s.mock.releasesHandler = { _, _, _ in
+            self.okResponse(self.makeDTOs(ids: [3, 2, 1]))
+        }
+
+        let report = await s.monitor.runOnce()
+        #expect(report.newReleasesByRepo[42] == 2) // 计数仍统计
+        #expect(report.notifications.isEmpty) // 但不进通知队列
+    }
+
+    @Test("404：仓库无 release → 不抛错 + 推进 lastPolledAt")
+    @MainActor
+    func notFoundDoesNotBreakLoop() async throws {
+        let s = try makeStack()
+        try await s.db.insertRepoFixture(id: 42)
+        try await s.subRepo.subscribe(repoId: 42, primingReleaseId: nil, primingTagName: nil)
+
+        s.mock.releasesHandler = { _, _, _ in
+            throw NetworkError.notFound
+        }
+
+        let report = await s.monitor.runOnce()
+        #expect(report.hasNewReleases == false)
+        #expect(report.perRepoErrors.isEmpty) // 404 是合法状态，不计为错误
+
+        let sub = try #require(try await s.subRepo.find(repoId: 42))
+        #expect(sub.lastPolledAt != nil)
+    }
+
+    @Test("单 repo 抛错：errors 记录，但其他 repo 仍继续巡检")
+    @MainActor
+    func errorOnOneRepoDoesNotStop() async throws {
+        let s = try makeStack()
+        try await s.db.insertRepoFixture(id: 1)
+        try await s.db.insertRepoFixture(id: 2)
+        try await s.subRepo.subscribe(repoId: 1, primingReleaseId: 1, primingTagName: "v1")
+        try await s.subRepo.subscribe(repoId: 2, primingReleaseId: 1, primingTagName: "v1")
+
+        s.mock.releasesHandler = { owner, repoName, _ in
+            // repo 1（owner=octo, name=demo-1）失败；repo 2 成功
+            if repoName == "demo-1" {
+                throw URLError(.timedOut)
+            }
+            return self.okResponse(self.makeDTOs(ids: [3, 2, 1]))
+        }
+
+        let report = await s.monitor.runOnce()
+        #expect(report.perRepoErrors.keys.contains(1))
+        // repo 2 走完整流程
+        #expect(report.newReleasesByRepo[2] == 2)
+        #expect(s.mock.releasesCalls.count == 2)
+    }
+
+    @Test("订阅指向不存在的 repo：跳过本次，不抛错")
+    @MainActor
+    func missingRepoSkipped() async throws {
+        let s = try makeStack()
+        // 没插 repos.id=999；直接手工写 release_subscriptions 行（绕开外键）
+        // 实际生产中外键 ON DELETE CASCADE 会删掉订阅，这里只是测兜底分支
+        try await s.db.writer.write { db in
+            try db.execute(sql: "PRAGMA foreign_keys = OFF")
+        }
+        defer {
+            // 测试结束恢复，避免影响其他 suite
+            // 注意：InMemoryDatabaseManager 每次 makeStack 都新建，无需手动恢复
+        }
+        try await s.db.insertRepoFixture(id: 1)
+        try await s.subRepo.subscribe(repoId: 1, primingReleaseId: 1, primingTagName: "v1")
+
+        // 删 repos.id=1 但 subscriptions 行仍在（模拟数据不一致）
+        try await s.db.writer.write { db in
+            try db.execute(sql: "DELETE FROM repos WHERE id = 1")
+        }
+
+        s.mock.releasesHandler = { _, _, _ in
+            self.okResponse(self.makeDTOs(ids: [2, 1]))
+        }
+
+        let report = await s.monitor.runOnce()
+        // missing repo → scanRepo 返回 (0, []) → 不计错误
+        #expect(report.perRepoErrors.isEmpty)
+        #expect(report.hasNewReleases == false)
+    }
+}

--- a/StarcatTests/ReleaseRepositoryTests.swift
+++ b/StarcatTests/ReleaseRepositoryTests.swift
@@ -1,0 +1,183 @@
+//
+//  ReleaseRepositoryTests.swift
+//  StarcatTests
+//
+//  HOM-47：GRDBReleaseRepository 单测。
+//
+//  覆盖：
+//  - upsertMany（首次插入 + 重复 upsert 保留 is_read）
+//  - latest / fetch（按 published_at 倒序）
+//  - fetchTimeline（仅取 is_subscribed=1 的 repo，按发布时间 desc）
+//  - markRead / markAllRead / markAllRead(forRepo:)
+//  - unreadCount（只计活跃订阅 + 未读）
+//
+
+import Testing
+import Foundation
+import GRDB
+@testable import Starcat
+
+@Suite("GRDBReleaseRepository")
+struct ReleaseRepositoryTests {
+
+    private func makeRepos() throws -> (
+        GRDBReleaseRepository,
+        GRDBReleaseSubscriptionRepository,
+        any DatabaseManaging
+    ) {
+        let db = try InMemoryDatabaseManager()
+        return (
+            GRDBReleaseRepository(database: db),
+            GRDBReleaseSubscriptionRepository(database: db),
+            db
+        )
+    }
+
+    private func makeRecord(
+        id: Int64,
+        repoId: Int64,
+        tag: String,
+        publishedAt: String? = "2026-06-01T00:00:00Z",
+        isRead: Bool = false
+    ) -> ReleaseRecord {
+        ReleaseRecord(
+            id: id,
+            repoId: repoId,
+            tagName: tag,
+            name: "Release \(tag)",
+            bodyTruncated: nil,
+            htmlUrl: "https://github.com/x/y/releases/tag/\(tag)",
+            isPrerelease: false,
+            isDraft: false,
+            publishedAt: publishedAt,
+            createdAtRemote: publishedAt,
+            assetsJson: nil,
+            isRead: isRead,
+            fetchedAt: "2026-06-04T00:00:00Z"
+        )
+    }
+
+    // MARK: - upsertMany
+
+    @Test("upsertMany: 首次插入 + 二次 upsert 保留 is_read=true")
+    func upsertManyPreservesIsRead() async throws {
+        let (repo, _, db) = try makeRepos()
+        try await db.insertRepoFixture(id: 10)
+
+        let r1 = makeRecord(id: 100, repoId: 10, tag: "v1.0")
+        try await repo.upsertMany([r1], isReadDefault: false)
+        try await repo.markRead(releaseId: 100, isRead: true)
+
+        // 二次 upsert 同 id：body / fetched_at 应被刷新，is_read 必须保留
+        var r1Updated = r1
+        r1Updated.bodyTruncated = "new body"
+        r1Updated.fetchedAt = "2026-06-05T00:00:00Z"
+        try await repo.upsertMany([r1Updated], isReadDefault: false)
+
+        let latest = try #require(try await repo.latest(forRepo: 10))
+        #expect(latest.bodyTruncated == "new body")
+        #expect(latest.fetchedAt == "2026-06-05T00:00:00Z")
+        #expect(latest.isRead == true) // 关键：upsert 不能踩平用户的已读状态
+    }
+
+    // MARK: - latest / fetch
+
+    @Test("latest: 按 published_at desc 取第一条")
+    func latestOrderByPublished() async throws {
+        let (repo, _, db) = try makeRepos()
+        try await db.insertRepoFixture(id: 10)
+
+        try await repo.upsertMany([
+            makeRecord(id: 1, repoId: 10, tag: "v1.0", publishedAt: "2026-05-01T00:00:00Z"),
+            makeRecord(id: 2, repoId: 10, tag: "v2.0", publishedAt: "2026-06-01T00:00:00Z"),
+            makeRecord(id: 3, repoId: 10, tag: "v1.5", publishedAt: "2026-05-15T00:00:00Z"),
+        ], isReadDefault: false)
+
+        let latest = try #require(try await repo.latest(forRepo: 10))
+        #expect(latest.tagName == "v2.0")
+    }
+
+    @Test("fetch: 按 published_at desc + 限制条数")
+    func fetchOrderAndLimit() async throws {
+        let (repo, _, db) = try makeRepos()
+        try await db.insertRepoFixture(id: 10)
+        try await repo.upsertMany([
+            makeRecord(id: 1, repoId: 10, tag: "v1.0", publishedAt: "2026-05-01T00:00:00Z"),
+            makeRecord(id: 2, repoId: 10, tag: "v2.0", publishedAt: "2026-06-01T00:00:00Z"),
+            makeRecord(id: 3, repoId: 10, tag: "v1.5", publishedAt: "2026-05-15T00:00:00Z"),
+        ], isReadDefault: false)
+
+        let got = try await repo.fetch(forRepo: 10, limit: 2)
+        #expect(got.map(\.tagName) == ["v2.0", "v1.5"])
+    }
+
+    // MARK: - fetchTimeline
+
+    @Test("fetchTimeline: 只列出 is_subscribed=1 的 repo，按发布时间 desc")
+    func fetchTimelineOnlyActive() async throws {
+        let (repo, sub, db) = try makeRepos()
+        try await db.insertRepoFixture(id: 10)
+        try await db.insertRepoFixture(id: 20)
+
+        // repo 10 订阅，repo 20 取消订阅
+        try await sub.subscribe(repoId: 10, primingReleaseId: nil, primingTagName: nil)
+        try await sub.subscribe(repoId: 20, primingReleaseId: nil, primingTagName: nil)
+        try await sub.unsubscribe(repoId: 20)
+
+        try await repo.upsertMany([
+            makeRecord(id: 1, repoId: 10, tag: "v1.0", publishedAt: "2026-05-01T00:00:00Z"),
+            makeRecord(id: 2, repoId: 10, tag: "v2.0", publishedAt: "2026-06-01T00:00:00Z"),
+            makeRecord(id: 3, repoId: 20, tag: "vX",   publishedAt: "2026-06-15T00:00:00Z"),
+        ], isReadDefault: false)
+
+        let timeline = try await repo.fetchTimeline(limit: 50)
+        #expect(timeline.count == 2)
+        #expect(timeline.map(\.release.tagName) == ["v2.0", "v1.0"])
+        #expect(timeline.allSatisfy { $0.repo.id == 10 })
+    }
+
+    // MARK: - markRead / markAllRead
+
+    @Test("markRead: 单条切换；markAllRead(forRepo:): 全部置已读")
+    func markReadOperations() async throws {
+        let (repo, _, db) = try makeRepos()
+        try await db.insertRepoFixture(id: 10)
+        try await repo.upsertMany([
+            makeRecord(id: 1, repoId: 10, tag: "v1"),
+            makeRecord(id: 2, repoId: 10, tag: "v2"),
+        ], isReadDefault: false)
+
+        try await repo.markRead(releaseId: 1, isRead: true)
+        let one = try #require(try await repo.fetch(forRepo: 10, limit: 50).first { $0.id == 1 })
+        #expect(one.isRead == true)
+
+        try await repo.markAllRead(forRepo: 10)
+        let all = try await repo.fetch(forRepo: 10, limit: 50)
+        #expect(all.allSatisfy { $0.isRead == true })
+    }
+
+    // MARK: - unreadCount
+
+    @Test("unreadCount: 仅活跃订阅 × 未读")
+    func unreadCountOnlyActive() async throws {
+        let (repo, sub, db) = try makeRepos()
+        try await db.insertRepoFixture(id: 10)
+        try await db.insertRepoFixture(id: 20)
+        try await sub.subscribe(repoId: 10, primingReleaseId: nil, primingTagName: nil)
+        try await sub.subscribe(repoId: 20, primingReleaseId: nil, primingTagName: nil)
+        try await sub.unsubscribe(repoId: 20)
+
+        // upsertMany 将 isReadDefault 应用到所有插入行；ReleaseRecord.isRead 字段在
+        // upsert 路径里仅作为 in-memory 视图（避免 DTO → record 转换时丢字段），
+        // 已读状态通过显式 markRead 设置。
+        try await repo.upsertMany([
+            makeRecord(id: 1, repoId: 10, tag: "v1"),
+            makeRecord(id: 2, repoId: 10, tag: "v2"),
+            makeRecord(id: 3, repoId: 20, tag: "vX"), // 不计：repo 已取消订阅
+        ], isReadDefault: false)
+        try await repo.markRead(releaseId: 2, isRead: true)
+
+        let count = try await repo.unreadCount()
+        #expect(count == 1) // 仅 id=1（repo 10 + 未读）
+    }
+}

--- a/StarcatTests/ReleaseSubscriptionRepositoryTests.swift
+++ b/StarcatTests/ReleaseSubscriptionRepositoryTests.swift
@@ -1,0 +1,138 @@
+//
+//  ReleaseSubscriptionRepositoryTests.swift
+//  StarcatTests
+//
+//  HOM-47：GRDBReleaseSubscriptionRepository 单测。
+//
+//  覆盖：
+//  - subscribe（首次插入 + 重新订阅保留 lastKnown 游标）
+//  - unsubscribe（仅置 is_subscribed=0，行保留）
+//  - setNotifyEnabled（开关静默）
+//  - updatePollCursor（推进游标 + lastPolledAt）
+//  - fetchActive（只返回 is_subscribed=1 的行）
+//
+
+import Testing
+import Foundation
+import GRDB
+@testable import Starcat
+
+@Suite("GRDBReleaseSubscriptionRepository")
+struct ReleaseSubscriptionRepositoryTests {
+
+    private func makeRepo() throws -> (GRDBReleaseSubscriptionRepository, any DatabaseManaging) {
+        let db = try InMemoryDatabaseManager()
+        return (GRDBReleaseSubscriptionRepository(database: db), db)
+    }
+
+    // MARK: - subscribe
+
+    @Test("subscribe: 首次写入 → is_subscribed=1 / notify_enabled=1 / lastKnown 写入")
+    func subscribeFirstTime() async throws {
+        let (repo, db) = try makeRepo()
+        try await db.insertRepoFixture(id: 42)
+
+        try await repo.subscribe(repoId: 42, primingReleaseId: 1001, primingTagName: "v1.0")
+
+        let got = try #require(try await repo.find(repoId: 42))
+        #expect(got.isSubscribed == true)
+        #expect(got.notifyEnabled == true)
+        #expect(got.lastKnownReleaseId == 1001)
+        #expect(got.lastKnownTagName == "v1.0")
+    }
+
+    @Test("subscribe: 重新订阅 → is_subscribed=1，原 lastKnown 不被 nil 覆盖（COALESCE）")
+    func resubscribePreservesCursor() async throws {
+        let (repo, db) = try makeRepo()
+        try await db.insertRepoFixture(id: 42)
+
+        try await repo.subscribe(repoId: 42, primingReleaseId: 1001, primingTagName: "v1.0")
+        try await repo.unsubscribe(repoId: 42)
+        // 重新订阅时不传 priming → 不应清空原游标
+        try await repo.subscribe(repoId: 42, primingReleaseId: nil, primingTagName: nil)
+
+        let got = try #require(try await repo.find(repoId: 42))
+        #expect(got.isSubscribed == true)
+        #expect(got.lastKnownReleaseId == 1001)
+        #expect(got.lastKnownTagName == "v1.0")
+    }
+
+    // MARK: - unsubscribe
+
+    @Test("unsubscribe: 仅置 is_subscribed=0，行保留 + lastKnown 保留")
+    func unsubscribeKeepsRow() async throws {
+        let (repo, db) = try makeRepo()
+        try await db.insertRepoFixture(id: 42)
+        try await repo.subscribe(repoId: 42, primingReleaseId: 1001, primingTagName: "v1.0")
+
+        try await repo.unsubscribe(repoId: 42)
+
+        let got = try #require(try await repo.find(repoId: 42))
+        #expect(got.isSubscribed == false)
+        #expect(got.lastKnownReleaseId == 1001) // 保留以供再次订阅
+    }
+
+    // MARK: - setNotifyEnabled
+
+    @Test("setNotifyEnabled: 切换 notify_enabled，不动 is_subscribed")
+    func setNotifyEnabledToggle() async throws {
+        let (repo, db) = try makeRepo()
+        try await db.insertRepoFixture(id: 42)
+        try await repo.subscribe(repoId: 42, primingReleaseId: 1, primingTagName: "v1")
+
+        try await repo.setNotifyEnabled(repoId: 42, enabled: false)
+        var got = try #require(try await repo.find(repoId: 42))
+        #expect(got.notifyEnabled == false)
+        #expect(got.isSubscribed == true)
+
+        try await repo.setNotifyEnabled(repoId: 42, enabled: true)
+        got = try #require(try await repo.find(repoId: 42))
+        #expect(got.notifyEnabled == true)
+    }
+
+    // MARK: - updatePollCursor
+
+    @Test("updatePollCursor: 推进 lastKnown + lastPolledAt")
+    func updatePollCursorAdvances() async throws {
+        let (repo, db) = try makeRepo()
+        try await db.insertRepoFixture(id: 42)
+        try await repo.subscribe(repoId: 42, primingReleaseId: 1, primingTagName: "v1")
+
+        // 用一个具体 Date 实例，断言时再用同一格式化器还原字符串避免 .withFractionalSeconds 噪音
+        let polled = Date(timeIntervalSince1970: 1_780_000_000)
+        let expectedISO = ISO8601DateFormatter.shared.string(from: polled)
+        try await repo.updatePollCursor(
+            repoId: 42,
+            latestReleaseId: 99,
+            latestTagName: "v9",
+            polledAt: polled
+        )
+
+        let got = try #require(try await repo.find(repoId: 42))
+        #expect(got.lastKnownReleaseId == 99)
+        #expect(got.lastKnownTagName == "v9")
+        #expect(got.lastPolledAt == expectedISO)
+    }
+
+    // MARK: - fetchActive
+
+    @Test("fetchActive: 只返回 is_subscribed=1 的订阅")
+    func fetchActiveOnly() async throws {
+        let (repo, db) = try makeRepo()
+        try await db.insertRepoFixture(id: 1)
+        try await db.insertRepoFixture(id: 2)
+        try await db.insertRepoFixture(id: 3)
+
+        try await repo.subscribe(repoId: 1, primingReleaseId: 1, primingTagName: "v1")
+        try await repo.subscribe(repoId: 2, primingReleaseId: 2, primingTagName: "v2")
+        try await repo.subscribe(repoId: 3, primingReleaseId: 3, primingTagName: "v3")
+        try await repo.unsubscribe(repoId: 2)
+
+        let active = try await repo.fetchActive()
+        let allRows = try await repo.fetchAll()
+
+        #expect(active.count == 2)
+        #expect(active.map(\.repoId).sorted() == [1, 3])
+        #expect(allRows.count == 3) // 行保留，仅 is_subscribed 切换
+    }
+}

--- a/docs/工程进度/功能实现总览.md
+++ b/docs/工程进度/功能实现总览.md
@@ -83,7 +83,7 @@
 | Week 3.1 | Sidebar 用户卡 + Keychain 持久化修复 | ✅ ⚠️ | 8/8（含 1 临时方案） |
 | **Week 4** | **README + 标签 + 笔记 + 状态 + 导入导出** | ⏳ 进行中 | **26/26 P0 实质完成**（W4-1：README WebView + 抓取缓存 + Phase 1 软过期/404 + Phase 2 SWR；W4-2：P0 重构债 D-01/02/03/04/05 + D-14 + T2.8 清零，单测 52→77；W4-3：标签/笔记/状态/多选/Sidebar Tags 等 Batch A+B 9 commit 一次落地，单测 77→152；W4-4：Batch C+D 7 commit 一次落地——同步系统 C1/C2/C3 + 列表 D1/D2/D3 + 缓存清理 D4，单测 152→188；W4-5：右侧详情页高度优化 + 滚动隐藏信息面板；HOM-25 主页按钮按三栏职责拆分 + Finder 式搜索框；HOM-43 Sidebar Tags/Languages 折叠 header 修复；剩余 JSON 导入/导出延后到 W5） |
 | Week 5 | CloudKit 同步 + 后台任务 | ⏳ | 0/8 |
-| Week 6 | P1 AI（摘要 / 标签推荐 / Release 订阅） | ⏳ | 6/15 |
+| Week 6 | P1 AI（摘要 / 标签推荐 / Release 订阅） | ⏳ | 14/15（HOM-47 Release 订阅追踪 8/9 子项落地） |
 | Week 7+ | P1 AI 语义搜索 + Trending + 订阅系统 | ⏳ | 9/19 |
 | Post-MVP | P2 多端 / 生态集成 / 高级 AI / 效率 | ⏳ | 0/27 |
 
@@ -349,17 +349,19 @@ W4-4 Batch C+D 一次落地 7 commit（C1 Rate Limit 退避 / C2 ETag 缓存 / C
 
 ## 4. P1 - 第一版 AI 功能
 
-### 4.1 Release 订阅追踪（差异化功能，优先做） ⏳（W6）
+### 4.1 Release 订阅追踪（差异化功能，优先做） ⏳（W6 8/9 完成；HOM-47）
 
-- [ ] **Release API 拉取** — `GET /repos/{owner}/{repo}/releases` — `ReleasesAPI.swift`（新增） — **W6**
-- [ ] **Release 订阅 / 取消订阅** — 详情页按钮 + `releases_subscriptions` 表 — **W6**
-- [ ] **后台轮询调度器** — `NSBackgroundActivityScheduler` — `Core/Scheduling/ReleasePoller.swift`（新增） — **W6**
-- [ ] **新 Release 通知** — `UNUserNotificationCenter` — **W6**
-- [ ] **Release 时间线视图** — 统一展示所有订阅 Release — `Features/Releases/ReleaseTimelineView.swift`（新增） — **W6**
-- [ ] **已读 / 未读管理** — Release 阅读状态 — **W6**
-- [ ] **智能资产过滤** — 按平台 / 文件类型 — **W7**
-- [ ] **一键复制下载链接** — 资产链接复制 — **W7**
+- [x] **Release API 拉取** — `GET /repos/{owner}/{repo}/releases` — `Core/Network/GitHubAPI/ReleasesAPI.swift`（新增） — **2026-06-04 完成（HOM-47）**
+- [x] **Release 订阅 / 取消订阅** — 详情页按钮（`Features/Releases/RepoReleaseSection.swift`）+ `release_subscriptions` 表（v6 迁移） — **2026-06-04 完成（HOM-47）**
+- [x] **后台轮询调度器** — `NSBackgroundActivityScheduler` — `Core/Scheduling/ReleasePoller.swift`（新增） — **2026-06-04 完成（HOM-47）**
+- [x] **新 Release 通知** — `UNUserNotificationCenter` — `Core/Sync/ReleaseNotificationService.swift`（新增） — **2026-06-04 完成（HOM-47）**
+- [x] **Release 时间线视图** — 统一展示所有订阅 Release — `Features/Releases/ReleaseTimelineView.swift`（新增） — **2026-06-04 完成（HOM-47）**
+- [x] **已读 / 未读管理** — Release 阅读状态（`releases.is_read` 列 + 单条切换 / 全部已读） — **2026-06-04 完成（HOM-47）**
+- [x] **智能资产过滤** — 按文件名 / contentType 关键字（time line 顶部 TextField） — **2026-06-04 完成（HOM-47）**
+- [x] **一键复制下载链接** — 资产行 `doc.on.clipboard` 按钮 + Toast 提示 — **2026-06-04 完成（HOM-47）**
 - [ ] **直接下载** — 可选直接下载 — **P1（W7，按 `docs/功能清单.md` §2.11 对齐）**
+
+> 实现（2026-06-04 HOM-47）：DB v6 迁移 `release_subscriptions`（订阅游标）+ `releases`（缓存）双表；GitHub Releases API + `GitHubReleaseDTO` / `GitHubReleaseAssetDTO`；`ReleaseSubscriptionRepository` / `ReleaseRepository` 走 GRDB writer，`upsertMany` 用 `ON CONFLICT(id) DO UPDATE` 不踩平用户 `is_read`；`ReleaseMonitor` actor 串行扫订阅，按 release id（不是 published_at，避免作者 backdate）过游标，404 也只更新 `last_polled_at`；`ReleaseNotificationService` 包 `UNUserNotificationCenter`，首次订阅自动请求授权、未授权时静默；`ReleasePoller` 走 `NSBackgroundActivityScheduler` 1h 间隔，登录态切换时启停；UI 端 `RepoReleaseSection` 详情页订阅按钮 + 通知静默开关 + 最新版本一行；`ReleaseTimelineView` 独立 sheet 聚合所有订阅 + 资产关键字过滤 + 复制 / 浏览器打开下载链接 + 全部已读。i18n en/zh-Hans 双语 30+ 键。`AppDependencies` 装配 4 个新单元；`SidebarView` 在 Manage 段加 "Release 时间线" 按钮入口。约束：① 仅做"列表 1 页 perPage=10"轮询，避免一次拉历史全量打爆 5000/h 配额；② 数据一致性：订阅指向已删 repo 时跳过本次扫描不抛错；③ 资产用 `assets_json TEXT` 直接存 JSON 字符串，不开 N 表（asset 数小，免 join）。新增单测 18 项（订阅 Repo / 缓存 Repo / Monitor 巡检），全套 267/267 通过。
 
 ### 4.2 AI 摘要与分析 ⏳（W6）
 
@@ -625,6 +627,7 @@ W4-4 Batch C+D 一次落地 7 commit（C1 Rate Limit 退避 / C2 ETag 缓存 / C
 | 2026-06-04 15:05 | 🐛 HOM-150 摘要折叠抖动 bugfix：dong4j 反馈"AI 回答时面板反复折叠/展开 + 手动折叠立刻被弹回"。根因两个反馈循环：① 流式每 token 触发 `proxy.scrollTo(.bottom)`，旧 hysteresis 把程序化跳变当用户滚动；② 手动折叠后 chat 视口被动放大 360pt，contentOffset 被布局推到 0，旧实现立刻判"在顶部"反向 expand。修复：`RepoAIWindowContentView` 新增 `lastChatScrollPhase: ScrollPhase`，chat ScrollView 挂 `.onScrollPhaseChange` 跟踪相位；`handleChatScroll` 双闸——(a) `chat.isSending` 为真时整段流式期跳过 hysteresis；(b) 只允许 `.tracking / .interacting / .decelerating` 三个用户手势驱动的相位翻折叠状态，`.animating`（程序化）和 `.idle`（布局抖动）一律 return。验证：`xcodebuild build` 通过、`xcodebuild test` 233 项 / 35 suites 全过。 |
 | 2026-06-04 14:40 | 🪟 HOM-150 AI 助手窗口体验回归优化（5 项 dong4j 反馈）：① 摘要流式生成支持实时滚动——`summarySection` ScrollView 包 `ScrollViewReader` + 底部 1pt `Color.clear` 锚点，`onChange(of: streamingSummaryText)` 实时 `scrollTo(.bottom)`，告别"等生成完才能看"；② 复制按钮加点击反馈——`@State didCopySummary` + 1.5s 复位 `Task`（旧任务先 cancel），icon 通过 `contentTransition(.symbolEffect(.replace))` 在 `doc.on.doc` ↔ `checkmark.circle.fill` 之间柔切，配合绿色 + tooltip "已复制 ✓"；③ 对话区背景改用 `Color(nsColor: .windowBackgroundColor)`（替换原 `.underPageBackgroundColor`），`AIChatBubble` 助手气泡去掉 `controlBackgroundColor` 背景（保留 sparkles 头像作为视觉锚），AI 回复在明暗主题下与窗口一体；④ 摘要 / 对话之间新增 `summaryCollapseDivider`——横线 + 居中胶囊 chevron + "折叠/展开 AI 摘要"文字 + `.pressableHover` 反馈，手动点击翻转 `isSummaryCollapsed`；同时 chat ScrollView 挂 `onScrollGeometryChange(for: CGFloat)`（macOS 15+ API），复用 `RepoDetailView` 同款 32/8pt hysteresis 自动折叠 / 恢复，空对话不参与；⑤ 摘要展开最大高度 280 → 360pt 让初次打开"更多展示摘要"，发首条消息时若摘要未折叠则带 0.3s 动画自动折叠把对话最大化。涉及 `Starcat/Features/AI/RepoAIWindowContentView.swift` / `Starcat/Features/AI/AIChatBubble.swift`。验证：`xcodebuild build` 通过；`xcodebuild test` Swift Testing 233 项 / 35 suites 仍全部通过。 |
 | 2026-06-04 14:10 | 🪟 HOM-150 AI 入口迁移到 Hero 卡片 + 新增 Chat 对话窗口：把 `RepoDetailView` 的 `README / AI` segmented tab 简化回单 README 视图，详情页 hero 区右上角新增紫蓝渐变 `sparkles + AI` 胶囊按钮（`.pressableHover()`）。点击通过新 `RepoAIWindowController` 打开按 `repo.id` 单例的浮动窗口（800×600 / 最小 600×400），内部 SwiftUI 视图 `RepoAIWindowContentView` 三段布局：顶部摘要 + 复制/重新生成按钮（限高 280pt + 内部 ScrollView）/ 中部对话气泡列表（`AIChatBubble` + ScrollViewReader 自动滚底）/ 底部 `AIChatInputView`（Return 即发送）。新增 `RepoAIChatViewModel` 独立管理流式对话，与既有 `RepoAIInsightViewModel` 解耦：重新生成摘要不清空对话、发送消息不影响摘要。`AIChatRequest` 扩展 `history: [AIChatMessage]`，`OpenAIClient.makeChatQuery` 按 user/assistant 映射到 MacPaw `ChatCompletionMessageParam`；`RepoAIInsightService.chatStream` 复用 `makeSource` 注入 repo 元数据 + README system prompt，强制流式响应。删除已无引用的 `Starcat/Features/AI/RepoAIInsightPanel.swift`。验证：`xcodegen generate` + `xcodebuild build` 通过；`xcodebuild test` Swift Testing 全量 233 项 / 35 suites 仍全部通过。仪表盘 P1 15 → 16，总计 75 → 76。 |
+| 2026-06-04 19:55 | 🚀 HOM-47 Release 订阅追踪 P1 差异化功能落地（W6 8/9）：① DB v6 迁移新增 `release_subscriptions`（订阅游标 + 通知静默开关）+ `releases`（缓存 + `is_read`）双表；② 新增 `GitHubReleaseDTO` / `GitHubReleaseAssetDTO` + `ReleasesAPI.swift` + 协议与 mock；③ `Core/Sync/ReleaseSubscriptionRepository` / `ReleaseRepository`（GRDB writer，`upsertMany` 走 `ON CONFLICT(id) DO UPDATE` 不踩平用户已读）；④ `Core/Sync/ReleaseMonitor` actor 串行扫订阅，按 release **id** 而非 `published_at` 过游标避免作者 backdate 误判，404 也只更新 `last_polled_at`；⑤ `Core/Sync/ReleaseNotificationService` 包 `UNUserNotificationCenter`，首次订阅请求授权、未授权静默；⑥ `Core/Scheduling/ReleasePoller` 走 `NSBackgroundActivityScheduler` 1h 间隔，登录态切换启停；⑦ UI：`Features/Releases/RepoReleaseSection` 详情页订阅按钮 + 通知静默开关 + 最新版本一行；`Features/Releases/ReleaseTimelineView` 独立 sheet 聚合所有订阅 + 资产关键字过滤 + 复制 / 浏览器打开下载 + 全部已读，`SidebarView` Manage 段加 "Release 时间线" 入口；⑧ i18n en/zh-Hans 双语 30+ 键。`AppDependencies` 装配 4 个新单元；新增单测 18 项（订阅 Repo / 缓存 Repo / Monitor 巡检），全套 267/267 通过。仅剩 §4.1 "直接下载"延后到 W7。约束：① 仅做"列表 1 页 perPage=10"轮询，避免一次拉历史全量打爆 5000/h 配额；② 数据一致性：订阅指向已删 repo 时跳过本次扫描不抛错；③ 资产用 `assets_json TEXT` 直接存 JSON 字符串，不开 N 表（asset 数小，免 join）；④ 旧 §3.3 "详情页最新 Release"现并入本特性的 `RepoReleaseSection`，不再单独建 `LatestReleaseRepository`。 |
 | 2026-06-04 12:42 | 🪟 AI 服务设置页动态放大：`SettingsView` 增加 `SettingsTab` selection 和 per-tab content size，通用 / 存储继续使用 520×360，AI 服务页切到 760×760，解决 AI 配置页内容显示不全。同步更新 `docs/详细设计/08-设置页面设计.md`。验证：`xcodebuild -scheme Starcat -destination 'platform=macOS,arch=arm64' build` 通过。 |
 | 2026-06-04 12:28 | 🔧 AI 设置模型列表与 Markdown 摘要优化：`AIModelListView` 将 provider 模型列表封装成 260pt 高度内部滚动组件，支持过滤和能力修正，避免大量模型撑高 Settings 页面；默认摘要 Prompt 恢复旧版信息密度，强制输出七段 Markdown；新增 `RepoAISummaryMarkdownView` 并引入 `gonzalezreal/swift-markdown-ui` 2.4.1，流式摘要实时 Markdown 渲染，README 仍保持 WebView。同步更新 `docs/详细设计/04-技术选型.md`、`14-AI集成落地记录.md`、`15-AI设置与调用链重构方案.md`。验证：`xcodegen generate` + `xcodebuild build` 通过；`xcodebuild test` 第二次全量通过，Swift Testing 233 tests / 35 suites。 |
 | 2026-06-04 11:47 | 🔧 AI 设置与调用链重构完成：新增 `AIConfiguration.swift`，将 AI 配置升级为多 provider profile + provider-scoped API Key + 模型启用列表 + 摘要/标签/Embedding 三任务独立模型配置；`AISettingsView` 拆成服务商、模型设置、参数、Prompt 四块，测试按钮调用模型列表接口并允许启用/禁用模型；`AIClientProtocol` / `OpenAIClient` 增加参数化 chat、`chatStream`、`listModels`，对 `finish_reason=length` 抛截断错误；`RepoAIInsightService` 把摘要流式自然语言输出与标签 JSON 解析拆成并行调用，标签失败不影响摘要；`SemanticSearchService` 改读独立 Embedding 任务。同步更新 `docs/详细设计/14-AI集成落地记录.md` 与 `docs/详细设计/15-AI设置与调用链重构方案.md`。验证：`xcodegen generate` + `xcodebuild build` + `xcodebuild test` 全通过，Swift Testing 233 项 / 35 suites。 |


### PR DESCRIPTION
## Summary

落地 [HOM-47](https://github.com/dong4j/Starcat/issues) **Release 订阅追踪** P1 差异化功能 — Starcat 区别于普通 Star 列表的核心能力之一。允许用户订阅特定 repo 的 Release 通知，背后用本地 `NSBackgroundActivityScheduler` 低频轮询 GitHub Releases API，新版本通过 `UNUserNotificationCenter` 发送系统通知，并提供独立时间线视图统一查看所有订阅的更新。

包含两个 commit：
- `108cc1c` 主体实现（数据层 + 网络层 + 业务调度 + UI + i18n + 18 项单测）
- `15c3267` dong4j review 后的 4 项 UI 优化（订阅按钮位置、tag 可点击、窗口尺寸、刷新图标动画）

## 实现要点

### 数据层（DB v6）
- `release_subscriptions`：订阅游标 + `notify_enabled` 单仓静默开关
- `releases`：缓存 + `is_read`，`assets_json TEXT` 直接存 JSON 免 join
- `upsertMany` 用 `ON CONFLICT(id) DO UPDATE` 不踩平用户已读状态

### 网络层
- `GitHubReleaseDTO` / `GitHubReleaseAssetDTO` + `ReleasesAPI.swift`
- `GitHubAPIClientProtocol.releases(owner:repo:perPage:)` + Mock 同步

### 业务调度
- `ReleaseMonitor` actor：串行扫订阅，按 release **id**（不是 `published_at`）过游标，避免作者 backdate 误判；404 也只更新 `last_polled_at`
- `ReleaseNotificationService`：包 `UNUserNotificationCenter`，首次订阅请求授权，未授权静默不抛错
- `ReleasePoller`：`NSBackgroundActivityScheduler` 1h 间隔，登录态切换启停

### UI
- `RepoReleaseSection`：详情页订阅按钮紧贴 "Releases" 标题（与 Tags 段对齐）+ 通知静默开关 + 最新 tag 直接可点跳转 GitHub（accent 色 + `.pressableHover()` hover 动效，与 Stars/Forks Stat Item 同款反馈）
- `ReleaseTimelineView`：独立 sheet 聚合所有订阅（minWidth 480 / idealWidth 587，按 dong4j 反馈减小 1/3）+ 资产关键字过滤 + 复制 / 浏览器打开下载 + 单条 / 全部已读 + 立即检查
- `ReleaseCheckNowButton`：与 SidebarSyncButton 视觉一致的 `arrow.triangle.2.circlepath` + 进行中线性 1s `repeatForever` 旋转
- `SidebarView` Manage 段加 "Release 时间线" 入口
- `AppDependencies` 装配 5 个新单元
- i18n en / zh-Hans 双语 30+ 键

## 关键设计取舍

- **API 配额保守**：仅拉一页 `perPage=10`；100 订阅 = 100 次/h，远低于 5000/h 主限流
- **新版本判定用 release.id**：GitHub release id 单调递增，比 `published_at` 鲁棒（作者 backdate 不会误推）
- **首次订阅 priming**：拉一页后把当前最新 id 作为游标，避免下次轮询把仓库历史所有 Release 当成新版本批量推通知给用户
- **轮询失败容忍**：单 repo 错误不打断整体巡检；订阅指向已删 repo 时跳过本次扫描不抛错
- **assets 用 JSON 列**：asset 数小，直接 `assets_json TEXT` 存 JSON 字符串，不开 N 表免 join

## 关联 Sub-issue 状态

父任务 HOM-47 下挂的 8 个 sub-issue（HOM-136~143）当前状态：
- ✅ done × 6：HOM-137 / 138 / 139 / 140 / 141 / 142
- ⛔ cancelled × 2：HOM-136（ETag 缓存）/ HOM-143（AI Release Notes 摘要）— 已与 dong4j 确认延后到独立排期

## Test plan

- [x] `xcodebuild -scheme Starcat -destination 'platform=macOS' build` 通过
- [x] `xcodebuild test`：全套 **267/267 通过**（新增 18 项：`ReleaseSubscriptionRepositoryTests` 6 + `ReleaseRepositoryTests` 6 + `ReleaseMonitorTests` 6）
- [ ] 手动验证：详情页订阅 / 取消订阅 → 订阅按钮位置正确、最新 tag 蓝色可点
- [ ] 手动验证：Sidebar "Release 时间线" 入口 → 时间线 sheet 宽度合适、立即检查按钮转圈动画与 SidebarSyncButton 一致
- [ ] 手动验证：触发新版本通知（可改 `last_known_release_id` 为旧值后立即检查）→ 系统通知弹出
- [ ] 手动验证：通知静默开关 → 关闭后新版本不弹通知但仍入库
- [ ] 手动验证：资产过滤关键字 / 复制下载链接 toast / 标记已读跨启动保持

Made with [Cursor](https://cursor.com)