### PR TITLE
fix(ReadmeWebView): 修复 README 相对链接解析错误 (HOM-146)

### DIFF
--- a/Starcat/Features/Activity/ActivityDetailView.swift
+++ b/Starcat/Features/Activity/ActivityDetailView.swift
@@ -277,7 +277,10 @@ struct ActivityDetailView: View {
         if let readmeVM {
             ReadmeStateView(
                 state: readmeVM.state,
-                baseURL: URL(string: repo.htmlUrl),
+                // 拼接 blob/HEAD：GitHub HTML 渲染 API 返回的相对链接缺少 blob/HEAD 前缀，
+                // 补上后相对链接才能正确解析为 https://github.com/owner/repo/blob/HEAD/xxx。
+                // 与 RepoDetailView.readmeSection / trendingReadmeSection 保持一致。
+                baseURL: URL(string: "\(repo.htmlUrl)/blob/HEAD"),
                 owner: repo.owner,
                 repo: repo.name,
                 onScrollOffsetChange: updateRepoMetadataPanelVisibility

--- a/Starcat/Features/Home/RepoDetailView.swift
+++ b/Starcat/Features/Home/RepoDetailView.swift
@@ -325,7 +325,10 @@ struct RepoDetailView: View {
     private func readmeSection(_ repo: Repo) -> some View {
         ReadmeStateView(
             state: readmeVM.state,
-            baseURL: URL(string: repo.htmlUrl),
+            // 拼接 blob/HEAD：GitHub HTML 渲染 API 返回的相对链接是相对于仓库根目录解析的，
+            // 缺少 blob/{branch} 前缀；补上后相对链接（如 README-en.md）才能正确解析为
+            // https://github.com/owner/repo/blob/HEAD/README-en.md。
+            baseURL: URL(string: "\(repo.htmlUrl)/blob/HEAD"),
             owner: repo.owner,
             repo: repo.name,
             onScrollOffsetChange: updateMetadataPanelVisibility
@@ -612,7 +615,9 @@ struct RepoDetailView: View {
     private func trendingReadmeSection(_ repo: TrendingRepo) -> some View {
         ReadmeStateView(
             state: readmeVM.state,
-            baseURL: repo.url,
+            // 拼接 blob/HEAD：同上，Trending 的 repo.url 是仓库根 URL，
+            // 补上 blob/HEAD 使相对链接正确解析。
+            baseURL: URL(string: "\(repo.url.absoluteString)/blob/HEAD"),
             owner: repo.owner,
             repo: repo.name,
             onScrollOffsetChange: updateMetadataPanelVisibility

--- a/StarcatTests/ReadmeWebViewTests.swift
+++ b/StarcatTests/ReadmeWebViewTests.swift
@@ -1,0 +1,115 @@
+//
+//  ReadmeWebViewTests.swift
+//  StarcatTests
+//
+//  HOM-146 配套单测：README WebView 相对链接解析修复。
+//
+//  测试内容：
+//  1. rewriteAssetURLs：图片相对路径重写（已知 working-case）
+//  2. rewriteOneAssetURL：单图 URL 各种输入的边界条件
+//
+//  注：链接（<a href>）的相对路径解析由 WKWebView 的 baseURL 机制处理，
+//  属于集成层面行为，不适合在纯 Swift 单测中覆盖（需要真实 WKWebView 环境）。
+//  RepoDetailView.swift 的 baseURL 已从 repo.htmlUrl 改为 repo.htmlUrl + "/blob/HEAD"，
+//  保证相对链接在 WebView 中被正确解析为 GitHub blob URL。
+//
+
+import Testing
+import Foundation
+@testable import Starcat
+
+@Suite("ReadmeWebView")
+struct ReadmeWebViewTests {
+
+    // MARK: - rewriteAssetURLs
+
+    @Test("相对路径图片重写为 raw.githubusercontent.com")
+    func rewriteAssetURLs_relativePath() {
+        let html = #"<img src="./logo.png" alt="logo">"#
+        let result = ReadmeWebView.rewriteAssetURLs(in: html, owner: "alice", repo: "foo")
+        #expect(result.contains("https://raw.githubusercontent.com/alice/foo/HEAD/logo.png"))
+    }
+
+    @Test("绝对 URL 图片不重写")
+    func rewriteAssetURLs_absoluteURL() {
+        let html = #"<img src="https://example.com/logo.png" alt="logo">"#
+        let result = ReadmeWebView.rewriteAssetURLs(in: html, owner: "alice", repo: "foo")
+        #expect(result.contains("https://example.com/logo.png"))
+        #expect(!result.contains("raw.githubusercontent.com"))
+    }
+
+    @Test("协议相对 // URL 不重写")
+    func rewriteAssetURLs_protocolRelative() {
+        let html = #"<img src="//avatars.githubusercontent.com/u/1234" alt="avatar">"#
+        let result = ReadmeWebView.rewriteAssetURLs(in: html, owner: "alice", repo: "foo")
+        #expect(result.contains("//avatars.githubusercontent.com"))
+        #expect(!result.contains("raw.githubusercontent.com"))
+    }
+
+    @Test("data: URI 不重写")
+    func rewriteAssetURLs_dataURI() {
+        let html = #"<img src="data:image/png;base64,abc123" alt="badge">"#
+        let result = ReadmeWebView.rewriteAssetURLs(in: html, owner: "alice", repo: "foo")
+        #expect(result.contains("data:image/png;base64,abc123"))
+    }
+
+    @Test("无 owner/repo 时不重写（保守策略）")
+    func rewriteAssetURLs_nilOwner() {
+        let html = #"<img src="./logo.png" alt="logo">"#
+        #expect(ReadmeWebView.rewriteAssetURLs(in: html, owner: nil, repo: "foo") == html)
+        #expect(ReadmeWebView.rewriteAssetURLs(in: html, owner: "alice", repo: nil) == html)
+        #expect(ReadmeWebView.rewriteAssetURLs(in: html, owner: "", repo: "foo") == html)
+    }
+
+    @Test("多张图片全部重写")
+    func rewriteAssetURLs_multipleImages() {
+        let html = """
+        <img src="./a.png">
+        <img src="./b.png">
+        <img src="https://example.com/c.png">
+        """
+        let result = ReadmeWebView.rewriteAssetURLs(in: html, owner: "bob", repo: "bar")
+        #expect(result.contains("raw.githubusercontent.com/bob/bar/HEAD/a.png"))
+        #expect(result.contains("raw.githubusercontent.com/bob/bar/HEAD/b.png"))
+        #expect(result.contains("https://example.com/c.png"))
+    }
+
+    @Test("嵌套属性 img 标签也能匹配")
+    func rewriteAssetURLs_imgWithOtherAttrs() {
+        let html = #"<img class="badge" src="./shield.svg" loading="lazy" alt="build">"#
+        let result = ReadmeWebView.rewriteAssetURLs(in: html, owner: "carol", repo: "baz")
+        #expect(result.contains("raw.githubusercontent.com/carol/baz/HEAD/shield.svg"))
+    }
+
+    // MARK: - rewriteOneAssetURL
+
+    @Test("不带 ./ 前缀的相对路径也能正确处理")
+    func rewriteOneAssetURL_withoutDotSlash() {
+        let rawBase = "https://raw.githubusercontent.com/alice/foo/HEAD/"
+        #expect(ReadmeWebView.rewriteOneAssetURL("logo.png", rawBase: rawBase) == rawBase + "logo.png")
+        #expect(ReadmeWebView.rewriteOneAssetURL("./logo.png", rawBase: rawBase) == rawBase + "logo.png")
+    }
+
+    @Test("前导斜杠被去掉以与仓库根对齐")
+    func rewriteOneAssetURL_leadingSlash() {
+        let rawBase = "https://raw.githubusercontent.com/alice/foo/HEAD/"
+        // 单层斜杠：典型真实路径，如 /images/logo.png
+        #expect(ReadmeWebView.rewriteOneAssetURL("/logo.png", rawBase: rawBase) == rawBase + "logo.png")
+    }
+
+    @Test("mailto: 和 javascript: 不重写")
+    func rewriteOneAssetURL_mailtoJS() {
+        let rawBase = "https://raw.githubusercontent.com/alice/foo/HEAD/"
+        #expect(ReadmeWebView.rewriteOneAssetURL("mailto:alice@example.com", rawBase: rawBase)
+            == "mailto:alice@example.com")
+        #expect(ReadmeWebView.rewriteOneAssetURL("javascript:void(0)", rawBase: rawBase)
+            == "javascript:void(0)")
+    }
+
+    @Test("空白和换行被 trim")
+    func rewriteOneAssetURL_whitespace() {
+        let rawBase = "https://raw.githubusercontent.com/alice/foo/HEAD/"
+        #expect(ReadmeWebView.rewriteOneAssetURL("  ./logo.png  \n", rawBase: rawBase)
+            == rawBase + "logo.png")
+    }
+}


### PR DESCRIPTION
## 问题

GitHub HTML render API 返回的相对链接（如 `README-en.md`）缺少 `blob/HEAD` 前缀，
在 WebView 的 `loadHTMLString(_, baseURL: repo.htmlUrl)` 中被错误解析为
`https://github.com/owner/repo/README-en.md` → **404**。

## 修复

三处 `ReadmeStateView` 的 `baseURL` 均加上 `/blob/HEAD` 后缀：

| 页面 | 文件 | 改动 |
|------|------|------|
| Manage 详情页 | `RepoDetailView.swift:328` | ✅ |
| Trending 详情页 | `RepoDetailView.swift:618` | ✅ |
| Activity 详情页 | `ActivityDetailView.swift:280` | ✅ |

## 测试

新增 `StarcatTests/ReadmeWebViewTests.swift`，11 个 case 覆盖图片 URL 重写逻辑。

## Commits

- `44ba800` fix(ReadmeWebView): 修复 README 相对链接解析错误
- `d8c51a4` fix(ActivityDetailView): 补充 Activity 页 README baseURL 的 blob/HEAD 前缀

Closes HOM-146