### PR TITLE
[codex] Add simulated Pro upgrade celebration

### DIFF
--- a/Starcat/Core/Settings/AppSettings.swift
+++ b/Starcat/Core/Settings/AppSettings.swift
@@ -456,6 +456,16 @@ final class AppSettings {
         didSet { persist(key: Keys.readmeTranslationLanguage, value: readmeTranslationLanguage.rawValue) }
     }
 
+    /// Pro 订阅模拟状态（HOM-151）。
+    ///
+    /// 真实 Apple 订阅接入前，设置页的"开通 Pro"按钮先写本地状态，用于串联：
+    /// - 开通成功反馈（彩纸动画 + 成功提示）
+    /// - 用户头像右下角 PRO 标识
+    /// 后续接入 StoreKit 后，只需要把订阅校验结果同步到这个状态入口。
+    var isProUser: Bool {
+        didSet { persistBool(key: Keys.isProUser, value: isProUser) }
+    }
+
     // MARK: - 初始化
 
     private let defaults: UserDefaults
@@ -543,6 +553,8 @@ final class AppSettings {
         let translationLangRaw = defaults.string(forKey: Keys.readmeTranslationLanguage)
         self.readmeTranslationLanguage = translationLangRaw
             .flatMap(ReadmeTranslationLanguage.init(rawValue:)) ?? .simplifiedChinese
+
+        self.isProUser = defaults.object(forKey: Keys.isProUser) as? Bool ?? false
     }
 
     // MARK: - 内部
@@ -685,5 +697,6 @@ final class AppSettings {
         static let smartSearchMode = "settings.search.mode"
         static let snakeStyle = "settings.contribution.snakeStyle"  // HOM-SNAKE-MODES
         static let readmeTranslationLanguage = "settings.readme.translation.language"  // HOM-68
+        static let isProUser = "settings.pro.isProUser"  // HOM-151
     }
 }

--- a/Starcat/Features/Settings/ProSettingsView.swift
+++ b/Starcat/Features/Settings/ProSettingsView.swift
@@ -1,0 +1,180 @@
+//
+//  ProSettingsView.swift
+//  Starcat
+//
+//  HOM-151：Pro 开通模拟页。
+//
+
+import SwiftUI
+import ConfettiSwiftUI
+
+/// Pro 订阅设置页。
+///
+/// 当前没有 Apple 开发者账号，暂不接 StoreKit；点击开通只写入本地模拟状态，
+/// 但后续彩纸动画、成功提示和头像 PRO 标识都走同一条状态链路。
+struct ProSettingsTab: View {
+
+    @Environment(AppSettings.self) private var settings
+
+    @State private var confettiTrigger: Int = 0
+    @State private var showSuccessMessage: Bool = false
+
+    var body: some View {
+        @Bindable var settings = settings
+
+        return Form {
+            Section {
+                VStack(alignment: .leading, spacing: 14) {
+                    HStack(alignment: .top, spacing: 14) {
+                        ZStack {
+                            Circle()
+                                .fill(
+                                    LinearGradient(
+                                        colors: [.yellow, .orange, .pink],
+                                        startPoint: .topLeading,
+                                        endPoint: .bottomTrailing
+                                    )
+                                )
+                                .frame(width: 48, height: 48)
+                            Image(systemName: "crown.fill")
+                                .font(.system(size: 22, weight: .semibold))
+                                .foregroundStyle(.white)
+                        }
+                        .shadow(color: .orange.opacity(0.25), radius: 10, y: 4)
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 8) {
+                                Text("Starcat Pro")
+                                    .font(.title3.weight(.semibold))
+                                if settings.isProUser {
+                                    ProStatusBadge()
+                                }
+                            }
+
+                            Text(settings.isProUser ? "已开通 Pro，头像会显示专属 PRO 标识。" : "开通后可立即预览 Pro 成功反馈与头像标识。")
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+
+                    Divider()
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        ProBenefitRow(systemImage: "sparkles", title: "AI 能力优先体验", detail: "后续 Pro 专属 AI 功能会优先在这里接入。")
+                        ProBenefitRow(systemImage: "paintpalette.fill", title: "专属身份标识", detail: "登录用户头像右下角展示醒目的 PRO 徽章。")
+                        ProBenefitRow(systemImage: "party.popper.fill", title: "开通成功礼炮", detail: "模拟开通成功后立即播放彩纸动画。")
+                    }
+
+                    HStack {
+                        Button {
+                            simulateUpgrade(settings: settings)
+                        } label: {
+                            Label(settings.isProUser ? "已开通 Pro" : "模拟开通 Pro", systemImage: settings.isProUser ? "checkmark.seal.fill" : "crown.fill")
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(settings.isProUser)
+
+                        if settings.isProUser {
+                            Button {
+                                settings.isProUser = false
+                                showSuccessMessage = false
+                            } label: {
+                                Label("重置模拟状态", systemImage: "arrow.counterclockwise")
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                    }
+                }
+                .padding(.vertical, 2)
+            } footer: {
+                Text("当前为前端模拟流程，不会发起 Apple 订阅或扣费。真实订阅接入后将复用同一套成功反馈。")
+            }
+
+            if showSuccessMessage {
+                Section {
+                    Label("Pro 已开通，欢迎加入 Starcat Pro。", systemImage: "checkmark.seal.fill")
+                        .foregroundStyle(.green)
+                        .font(.callout.weight(.medium))
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .confettiCannon(
+            trigger: $confettiTrigger,
+            num: 60,
+            confettis: [
+                .shape(.circle),
+                .shape(.triangle),
+                .shape(.square),
+                .shape(.slimRectangle),
+                .text("PRO")
+            ],
+            colors: [.yellow, .orange, .red, .pink, .purple, .green, .blue],
+            confettiSize: 12,
+            rainHeight: 520,
+            fadesOut: true,
+            openingAngle: Angle(degrees: 0),
+            closingAngle: Angle(degrees: 360),
+            radius: 260,
+            repetitions: 3,
+            repetitionInterval: 0.7,
+            hapticFeedback: false
+        )
+    }
+
+    private func simulateUpgrade(settings: AppSettings) {
+        settings.isProUser = true
+        showSuccessMessage = true
+        confettiTrigger += 1
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(4))
+            showSuccessMessage = false
+        }
+    }
+}
+
+private struct ProBenefitRow: View {
+
+    let systemImage: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: systemImage)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.orange)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.callout.weight(.medium))
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+}
+
+private struct ProStatusBadge: View {
+    var body: some View {
+        Text("PRO")
+            .font(.system(size: 10, weight: .black))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(
+                Capsule()
+                    .fill(
+                        LinearGradient(
+                            colors: [.orange, .pink],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+            )
+    }
+}

--- a/Starcat/Features/Settings/SettingsView.swift
+++ b/Starcat/Features/Settings/SettingsView.swift
@@ -37,6 +37,7 @@ struct SettingsView: View {
     /// 不会被裁切。
     private enum SettingsTab: Hashable {
         case general
+        case pro
         case ai
         case storage
     }
@@ -59,6 +60,11 @@ struct SettingsView: View {
                     Label("settings.storage.title", systemImage: "internaldrive")
                 }
                 .tag(SettingsTab.storage)
+            ProSettingsTab()
+                .tabItem {
+                    Label("Pro", systemImage: "crown.fill")
+                }
+                .tag(SettingsTab.pro)
             AISettingsTab()
                 .tabItem {
                     Label("settings.ai.title", systemImage: "sparkles")

--- a/Starcat/Shared/Components/RemoteAvatar.swift
+++ b/Starcat/Shared/Components/RemoteAvatar.swift
@@ -72,6 +72,8 @@ struct RemoteAvatar: View {
 /// - 未登录：显示默认图标，点击打开登录弹窗
 /// - 已登录：显示远程头像，点击打开 GitHub 用户主页
 struct UserAvatar: View {
+    @Environment(AppSettings.self) private var settings
+
     /// 是否已登录
     let isLoggedIn: Bool
     /// 用户头像 URL（已登录时使用）
@@ -93,9 +95,17 @@ struct UserAvatar: View {
             }
         } label: {
             if isLoggedIn {
-                RemoteAvatar(urlString: avatarUrl, size: size)
-                    .fixedSize()
-                    .frame(maxWidth: .infinity)
+                ZStack(alignment: .bottomTrailing) {
+                    RemoteAvatar(urlString: avatarUrl, size: size)
+                        .fixedSize()
+
+                    if settings.isProUser {
+                        AvatarProBadge()
+                            .offset(x: 5, y: 3)
+                    }
+                }
+                .frame(width: size + 10, height: size + 6)
+                .frame(maxWidth: .infinity)
             } else {
                 Image(systemName: "person.crop.circle.fill")
                     .resizable()
@@ -116,5 +126,31 @@ struct UserAvatar: View {
     private func openGitHubProfile(login: String) {
         guard let url = URL(string: "https://github.com/\(login)") else { return }
         NSWorkspace.shared.open(url)
+    }
+}
+
+private struct AvatarProBadge: View {
+    var body: some View {
+        Text("PRO")
+            .font(.system(size: 8, weight: .black))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background {
+                Capsule()
+                    .fill(
+                        LinearGradient(
+                            colors: [.yellow, .orange, .pink],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .shadow(color: .black.opacity(0.18), radius: 2, y: 1)
+            }
+            .overlay {
+                Capsule()
+                    .stroke(.white.opacity(0.75), lineWidth: 0.7)
+            }
+            .accessibilityLabel(Text("Pro"))
     }
 }

--- a/StarcatTests/AppSettingsTests.swift
+++ b/StarcatTests/AppSettingsTests.swift
@@ -40,6 +40,18 @@ struct AppSettingsTests {
         #expect(s2.listDensity == .compact)
     }
 
+    @Test("Pro: 默认非 Pro，设置后重新读取应保留")
+    func proStatusPersists() {
+        let defaults = makeIsolatedDefaults()
+        let s1 = AppSettings(defaults: defaults)
+        #expect(s1.isProUser == false)
+
+        s1.isProUser = true
+
+        let s2 = AppSettings(defaults: defaults)
+        #expect(s2.isProUser == true)
+    }
+
     @Test("非法 raw value 回退到默认")
     func invalidValueFallsBack() {
         let defaults = makeIsolatedDefaults()

--- a/project.yml
+++ b/project.yml
@@ -47,6 +47,9 @@ packages:
   OpenAI:
     url: https://github.com/MacPaw/OpenAI.git
     branch: main
+  ConfettiSwiftUI:
+    url: https://github.com/simibac/ConfettiSwiftUI.git
+    branch: master
 
 targets:
   Starcat:
@@ -74,6 +77,7 @@ targets:
       - package: Kingfisher
       - package: MarkdownUI
       - package: OpenAI
+      - package: ConfettiSwiftUI
 
   StarcatTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary
- Add a Pro tab in Settings with a simulated upgrade action.
- Persist local Pro state for later StoreKit integration.
- Trigger a ConfettiSwiftUI celebration after upgrade and show a PRO badge on the logged-in avatar.

## Validation
- `xcodebuild test -project Starcat.xcodeproj -scheme Starcat -destination 'platform=macOS' -only-testing:StarcatTests/AppSettingsTests`

Issue: HOM-151
