### PR TITLE
[HOM-175] fix(sidebar): 修复窗口最大化时头像区域被拉伸的布局问题

### DIFF
--- a/Starcat/Features/Home/SidebarHeaderView.swift
+++ b/Starcat/Features/Home/SidebarHeaderView.swift
@@ -72,6 +72,12 @@ struct SidebarHeaderView: View {
         .padding(.top, 14)
         .padding(.bottom, 12)
         .background(alignment: .top) { sidebarTintBackground }
+        // HOM-175：防御性兜底，强制整张头像卡严格按内容尺寸（垂直方向不被拉伸）。
+        // 即便未来子视图（avatarRow / ProfileLinksRow / statsRow）再次引入垂直
+        // flexible 元素（Spacer / .frame(maxHeight: .infinity) 等），SidebarHeaderView
+        // 整体高度依然由 ideal size 决定，不会与同栏的 sidebarList 抢占可用高度。
+        // 水平方向继续随父级宽度扩展（保持 sidebar 240~320pt 范围内填满）。
+        .fixedSize(horizontal: false, vertical: true)
         .sheet(isPresented: $showLoginSheet) {
             GithubAuthView()
         }
@@ -304,7 +310,26 @@ struct SidebarHeaderView: View {
         // ① UserAvatar 是 Button（点击跳 GitHub 主页），把另一个 Button 嵌进它的 label 里
         //    会产生嵌套 Button 的命中冲突；外层 ZStack 让两个按钮各自独立可点。
         // ② 与右上角已有的 accountMenu() 处理方式保持一致。
-        ZStack {
+        //
+        // **HOM-175 2026-06-06 修复（dong4j 反馈：窗口最大化时头像区域被拉长）**：
+        // 之前用两个 `VStack { HStack {...}; Spacer() }` 把按钮推到顶部。
+        // `Spacer()` 在垂直方向是无限灵活的（min 0、max ∞），
+        // 让两个 VStack 的 ideal 高度变成"想要无限大"，
+        // 进而让 ZStack 的 ideal 高度也变成"想要无限大"。
+        // 这条灵活性传染到外层 `VStack(spacing: 10)`、`SidebarHeaderView`、
+        // `SidebarView` 最外层 `VStack(spacing: 0) { sidebarFixedHeader; sidebarList }`，
+        // 与 `sidebarList`（List 本身也 flexible）一起变成"按比例分配可用高度"，
+        // 窗口越高 → sidebarFixedHeader 越被拉长 → ZStack 内 UserAvatar 居中显示，
+        // profile links 行和 stats 区域之间凭空多出一段空白。
+        //
+        // 修复：用 `ZStack(alignment: .top)` 让所有子项顶部对齐，
+        // 并把两个独立 VStack 合并成一条 HStack（左按钮 + Spacer + 右按钮）。
+        // 此时 ZStack ideal 高度 = max(UserAvatar 高 62pt, HStack 高 22pt) = 62pt，
+        // 不再含 Spacer → 不再 flexible → 不再传染拉伸。
+        // HStack 内部水平方向上的 `Spacer()` 不影响垂直 ideal 高度，是合法用法。
+        //
+        // 视觉上完全等效：原方案中按钮也是顶对齐（VStack 顶部 = ZStack 顶部 = 头像顶部）。
+        ZStack(alignment: .top) {
             // 头像（最底层）
             UserAvatar(
                 isLoggedIn: true,
@@ -313,22 +338,11 @@ struct SidebarHeaderView: View {
                 onLoginTapped: { showLoginSheet = true }
             )
 
-            // 左上角：分享卡入口
-            VStack {
-                HStack {
-                    shareCardButton()
-                    Spacer()
-                }
+            // 顶部浮动按钮行：左侧分享卡入口、右侧账户菜单。
+            HStack {
+                shareCardButton()
                 Spacer()
-            }
-
-            // 右上角：账户菜单
-            VStack {
-                HStack {
-                    Spacer()
-                    accountMenu()
-                }
-                Spacer()
+                accountMenu()
             }
         }
     }


### PR DESCRIPTION
## 背景

dong4j 反馈：Starcat 主窗口最大化（或拉到很大）时，左侧 Sidebar 顶部的头像区域（`SidebarHeaderView`）被垂直拉长，profile links 行与 stats 区域之间凭空多出一段空白；小窗口时比例正常。

issue: [HOM-175](mention://issue/131ef58b-35eb-4c09-85c6-ea30004f4a92)

## 根因

`avatarRow(user:)` 的 ZStack 内部用了两个 `VStack { HStack {...}; Spacer() }` 把按钮固定在头像顶部。`Spacer()` 在垂直方向是无限灵活的（min 0、max ∞），让两个 `VStack` 的 ideal 高度变成"想要无限大"，进而让外层 ZStack、`VStack(spacing: 10)`、`SidebarHeaderView` 整体的 ideal 高度都变成"想要无限大"。

这条灵活性传到 `SidebarView` 最外层 `VStack(spacing: 0) { sidebarFixedHeader; sidebarList }` 时，`sidebarFixedHeader` 与 `sidebarList`（List 自身也是 flexible）一起被 SwiftUI 当成"按比例分配剩余高度"的同辈节点。窗口越高 → `sidebarFixedHeader` 拿到越多空间 → ZStack 内 `UserAvatar`（默认 `.center`）居中显示 → 头像下方多出空白，看起来"profile links 行和 stats 区域之间间距变大"。

## 修复

`Starcat/Features/Home/SidebarHeaderView.swift`：

1. **核心修复**：把 `avatarRow` 的 `ZStack` 改成 `ZStack(alignment: .top)`，去掉两个独立 `VStack`，改用单条 `HStack { 左按钮; Spacer(); 右按钮 }` 作为顶部浮动按钮行。
   - HStack 中的 `Spacer()` 仅在水平方向灵活，不影响垂直 ideal 高度。
   - ZStack 的 ideal 高度回到 `max(UserAvatar 62pt, HStack 22pt) = 62pt`，不再 flexible，不再传染拉伸。
   - 按钮视觉位置完全不变（原本就是顶对齐）。

2. **防御性兜底**：在 `SidebarHeaderView` body 末尾追加 `.fixedSize(horizontal: false, vertical: true)`。即便未来 `avatarRow` / `ProfileLinksRow` / `statsRow` 再次引入垂直 flexible 元素，`SidebarHeaderView` 整体高度依然由 ideal size 决定，不会与同栏的 `sidebarList` 抢占可用高度；水平方向继续随父级宽度扩展。

代码改动伴随详细中文注释，记录"为什么这样做"和未来改动时需要注意的关键约束。

## 验收

- [x] `xcodegen generate` + `xcodebuild -scheme Starcat -configuration Debug -sdk macosx -arch arm64 build` 全量构建通过（`** BUILD SUCCEEDED **`）。
- [ ] 在不同窗口尺寸下手动验证（最小 1440×763、默认、最大化）头像区域高度保持稳定，profile links 与 stats 间距正常 —— 需要 dong4j 在本机 Xcode 跑一次确认。
- [ ] Accessibility 大字体下检查。

## 影响范围

仅修改 `SidebarHeaderView.swift` 一个文件，没有触碰外层 `SidebarView` / `HomeView` 布局，不影响任何其他视图。

Made with [Cursor](https://cursor.com)