### PR TITLE
feat(HOM-52): 批量未分类仓库 AI 整理（队列 + 浮动面板）

### DIFF
--- a/Starcat/App/AppDependencies.swift
+++ b/Starcat/App/AppDependencies.swift
@@ -58,6 +58,13 @@ final class AppDependencies {
     /// W6 AI：单仓 AI 摘要与标签推荐服务。
     let repoAIInsightService: RepoAIInsightService
 
+    /// HOM-52：批量未分类仓库 AI 整理队列服务（会话级单例）。
+    ///
+    /// 单例理由：同时只允许跑一批整理任务，避免 AI 配额尖刺，且 panel/banner 多处订阅
+    /// 同一份状态。装在 AppDependencies 让 HomeView 通过 environment 注入到 RepoListView /
+    /// BatchAIQueuePanel / BatchAIUntaggedBanner，无需多余的 @State 传参。
+    let batchAIQueueService: BatchAIQueueService
+
     // MARK: - HOM-68 README 翻译
 
     /// README AI 翻译缓存 Repository。
@@ -165,11 +172,12 @@ final class AppDependencies {
 
         let summaryRepo = GRDBAISummaryRepository(database: db)
         self.aiSummaryRepository = summaryRepo
-        self.repoAIInsightService = RepoAIInsightService(
+        let aiInsight = RepoAIInsightService(
             summaryRepository: summaryRepo,
             readmeRepository: readmeRepo,
             settings: self.settings
         )
+        self.repoAIInsightService = aiInsight
 
         // HOM-68：README 翻译。复用 AppSettings.aiSummaryTask 的 provider/model 选择
         // 与 Keychain API Key，独立 Service 承载严格保结构的翻译 prompt + 本地 SQLite 缓存。
@@ -181,9 +189,20 @@ final class AppDependencies {
         )
 
         // W4 Batch A1：标签 / 关联 / 笔记+状态 Repository
-        self.tagRepository = GRDBTagRepository(database: db)
-        self.repoTagRepository = GRDBRepoTagRepository(database: db)
+        let tagRepo = GRDBTagRepository(database: db)
+        let repoTagRepo = GRDBRepoTagRepository(database: db)
+        self.tagRepository = tagRepo
+        self.repoTagRepository = repoTagRepo
         self.repoNoteRepository = GRDBRepoNoteRepository(database: db)
+
+        // HOM-52：批量整理服务装在 AI insight + 标签 + 标签关联 + AI 摘要 Repo 之后。
+        // 注：onTagsChanged 由 HomeView 在 environment 注入后挂接，刷新 Sidebar 计数。
+        self.batchAIQueueService = BatchAIQueueService(
+            insightService: aiInsight,
+            tagRepository: tagRepo,
+            repoTagRepository: repoTagRepo,
+            aiSummaryRepository: summaryRepo
+        )
         let embeddingRepo = GRDBRepoEmbeddingRepository(database: db)
         self.repoEmbeddingRepository = embeddingRepo
         self.semanticSearchService = SemanticSearchService(

--- a/Starcat/Features/AI/BatchAIOptionsSheet.swift
+++ b/Starcat/Features/AI/BatchAIOptionsSheet.swift
@@ -11,8 +11,15 @@
 //
 //  关键约束：
 //  - 默认值与 dong4j 2026-06-06 评审决议一致：actions=[summary,tags]、autoApply=false、threshold=0.90。
-//  - 置信度滑条仅在 autoApplyTags 打开时显示，避免无谓配置项干扰。
 //  - 启动按钮在 actions 为空 / repo 数为 0 时禁用，避免误触发。
+//
+//  UI 设计（2026-06-06 17:51 dong4j 反馈"系统 toggle 太丑"重做）：
+//  - 抛弃 `Toggle(...).toggleStyle(.switch)`：macOS 26 的系统 switch 颗粒粗、
+//    放在小窗口里视觉权重过大，让 sheet 看着像"安卓系统设置"。
+//  - 改用 **可点击卡片 + 圆形 checkmark**：整行点击切换，圆形勾选标记替代 toggle，
+//    视觉重量更轻。选中态用 tint 淡色背景 + 描边明确反馈。
+//  - hover 反馈复用项目共享 `PressableHover`，与详情页可点击元素一致。
+//  - 自动应用 / 阈值滑条作为"标签"的子设置缩进展示，依赖关系清晰。
 //
 
 import SwiftUI
@@ -29,121 +36,158 @@ struct BatchAIOptionsSheet: View {
     private static let avgSecondsPerRepo: Double = 8.0
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 18) {
             header
-
-            Divider()
-
             actionsSection
-
-            autoApplySection
-
-            Divider()
-
+            autoApplyCard
             footer
         }
         .padding(20)
-        .frame(width: 460)
+        .frame(width: 480)
     }
 
-    // MARK: - 子视图
+    // MARK: - Header
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 8) {
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(.tint.opacity(0.12))
                 Image(systemName: "sparkles")
+                    .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(.tint)
+            }
+            .frame(width: 36, height: 36)
+
+            VStack(alignment: .leading, spacing: 2) {
                 Text("batchAI.options.title")
                     .font(.headline)
+                Text(String(format: String(localized: "batchAI.options.subtitleFormat"), pendingCount))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
             }
-            Text(String(format: String(localized: "batchAI.options.subtitleFormat"), pendingCount))
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-            estimateLabel
+
+            Spacer()
+
+            estimateChip
         }
     }
 
-    @ViewBuilder
-    private var estimateLabel: some View {
+    private var estimateChip: some View {
         let seconds = Double(pendingCount) * Self.avgSecondsPerRepo
         let minutes = max(1, Int((seconds / 60).rounded(.up)))
-        Text(String(format: String(localized: "batchAI.options.estimateFormat"), minutes))
-            .font(.caption)
-            .foregroundStyle(.tertiary)
+        return HStack(spacing: 4) {
+            Image(systemName: "clock")
+                .font(.caption2)
+            Text(String(format: String(localized: "batchAI.options.estimateFormat"), minutes))
+                .font(.caption.monospacedDigit())
+        }
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color.secondary.opacity(0.08), in: Capsule())
     }
+
+    // MARK: - Actions Section（两个操作卡片）
 
     private var actionsSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("batchAI.options.actionsLabel")
-                .font(.subheadline.weight(.medium))
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
 
-            ToggleRow(
-                isOn: actionBinding(for: .summary),
-                title: "batchAI.options.action.summary",
-                subtitle: "batchAI.options.action.summary.desc",
-                systemImage: "doc.text"
-            )
-            ToggleRow(
-                isOn: actionBinding(for: .tags),
-                title: "batchAI.options.action.tags",
-                subtitle: "batchAI.options.action.tags.desc",
-                systemImage: "tag"
-            )
+            VStack(spacing: 8) {
+                OptionCard(
+                    icon: "doc.text",
+                    title: "batchAI.options.action.summary",
+                    subtitle: "batchAI.options.action.summary.desc",
+                    isSelected: options.actions.contains(.summary),
+                    onToggle: { toggleAction(.summary) }
+                )
+                OptionCard(
+                    icon: "tag",
+                    title: "batchAI.options.action.tags",
+                    subtitle: "batchAI.options.action.tags.desc",
+                    isSelected: options.actions.contains(.tags),
+                    onToggle: { toggleAction(.tags) }
+                )
+            }
         }
     }
 
-    @ViewBuilder
-    private var autoApplySection: some View {
+    // MARK: - Auto-apply Card（带子设置：阈值滑条）
+
+    private var autoApplyCard: some View {
         let tagsEnabled = options.actions.contains(.tags)
 
-        VStack(alignment: .leading, spacing: 8) {
-            Toggle(isOn: $options.autoApplyTags) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("batchAI.options.autoApply")
-                        .font(.subheadline.weight(.medium))
-                    Text("batchAI.options.autoApply.desc")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+        return VStack(alignment: .leading, spacing: 10) {
+            OptionCard(
+                icon: "checkmark.seal",
+                title: "batchAI.options.autoApply",
+                subtitle: "batchAI.options.autoApply.desc",
+                isSelected: options.autoApplyTags,
+                isDisabled: !tagsEnabled,
+                onToggle: {
+                    guard tagsEnabled else { return }
+                    options.autoApplyTags.toggle()
                 }
-            }
-            .toggleStyle(.switch)
-            .disabled(!tagsEnabled)
+            )
 
             if options.autoApplyTags, tagsEnabled {
                 thresholdSlider
+                    .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
+        .animation(.easeInOut(duration: 0.18), value: options.autoApplyTags)
     }
 
     private var thresholdSlider: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
                 Text("batchAI.options.threshold")
-                    .font(.caption)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
                 Spacer()
                 Text(verbatim: percentString(options.confidenceThreshold))
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
+                    .font(.caption.weight(.semibold).monospacedDigit())
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 2)
+                    .background(.tint.opacity(0.15), in: Capsule())
+                    .foregroundStyle(.tint)
             }
+
             Slider(value: $options.confidenceThreshold, in: 0.5...1.0, step: 0.05)
+                .controlSize(.mini)
+                .tint(.accentColor)
+
             Text(String(format: String(localized: "batchAI.options.threshold.hintFormat"), percentString(options.confidenceThreshold)))
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
         }
-        .padding(.leading, 28)
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.secondary.opacity(0.06))
+        )
+        .padding(.leading, 36)  // 视觉上缩进，体现"自动应用"的子设置层级
     }
+
+    // MARK: - Footer
 
     private var footer: some View {
         HStack {
             Spacer()
             Button("general.cancel", action: onCancel)
                 .keyboardShortcut(.cancelAction)
+                .controlSize(.large)
             Button {
                 onStart()
             } label: {
                 Text(String(format: String(localized: "batchAI.options.startFormat"), pendingCount))
             }
             .buttonStyle(.borderedProminent)
+            .controlSize(.large)
             .keyboardShortcut(.defaultAction)
             .disabled(!options.isValidForStart || pendingCount == 0)
         }
@@ -151,19 +195,12 @@ struct BatchAIOptionsSheet: View {
 
     // MARK: - 辅助
 
-    /// 把 actions Set 投影成单个 Action 的 Toggle binding。
-    /// Toggle 切换时 add/remove 即可，逻辑短小不抽函数。
-    private func actionBinding(for action: BatchAIAction) -> Binding<Bool> {
-        Binding(
-            get: { options.actions.contains(action) },
-            set: { newValue in
-                if newValue {
-                    options.actions.insert(action)
-                } else {
-                    options.actions.remove(action)
-                }
-            }
-        )
+    private func toggleAction(_ action: BatchAIAction) {
+        if options.actions.contains(action) {
+            options.actions.remove(action)
+        } else {
+            options.actions.insert(action)
+        }
     }
 
     private func percentString(_ v: Double) -> String {
@@ -171,31 +208,116 @@ struct BatchAIOptionsSheet: View {
     }
 }
 
-// MARK: - ToggleRow
+// MARK: - OptionCard
 
-/// "操作选择 Sheet"内复用的 Toggle 行：左图标 + 标题 + 副标题 + 右开关。
-/// 不外迁到 Components/，因为只在本 sheet 使用且语义紧耦合。
-private struct ToggleRow: View {
-    let isOn: Binding<Bool>
+/// 可点击卡片，代替 system Toggle.switch。
+///
+/// 视觉规范：
+/// - 圆角 10pt、内边距 12pt、最小高度 56pt
+/// - 左侧图标固定 28×28 圆角容器，selected 时填充 tint，unselected 时浅灰
+/// - 右侧 18pt 圆形 checkmark，selected = tint 实心 + 白勾，unselected = 描边空心圆
+/// - 选中态：背景 `tint.opacity(0.08)` + 描边 `tint.opacity(0.35)`
+/// - 未选中态：背景透明 + 描边 `secondary.opacity(0.18)`
+/// - hover：背景叠加 `secondary.opacity(0.05)`
+/// - disabled：整卡 opacity 0.45，不响应点击
+///
+/// 比起 `.toggleStyle(.switch)` 的好处：
+/// - macOS 26 的 system switch 颗粒粗（~30×18pt），三个堆在一起视觉很重；
+///   圆形 checkmark 仅 18pt，视觉重量是 switch 的 1/3。
+/// - 整卡可点击，命中区域大；用户不必精准点中右侧那个小开关。
+/// - 选中态用背景色 + 描边表达，比 switch 的"半截绿条"更明显。
+private struct OptionCard: View {
+
+    let icon: String
     let title: LocalizedStringKey
     let subtitle: LocalizedStringKey
-    let systemImage: String
+    let isSelected: Bool
+    var isDisabled: Bool = false
+    let onToggle: () -> Void
+
+    @State private var isHovered: Bool = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        Toggle(isOn: isOn) {
-            HStack(spacing: 10) {
-                Image(systemName: systemImage)
-                    .font(.system(size: 16))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 22)
+        Button {
+            onToggle()
+        } label: {
+            HStack(spacing: 12) {
+                iconBadge
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(title).font(.subheadline)
+                    Text(title)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.primary)
                     Text(subtitle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
+                Spacer(minLength: 8)
+                checkmark
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .background(cardBackground)
+            .overlay(cardBorder)
+        }
+        .buttonStyle(.plain)
+        .focusEffectDisabled()
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.45 : 1.0)
+        .onHover { hovering in
+            withAnimation(.easeOut(duration: reduceMotion ? 0 : 0.12)) {
+                isHovered = hovering && !isDisabled
             }
         }
-        .toggleStyle(.switch)
+    }
+
+    private var iconBadge: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(isSelected ? Color.accentColor.opacity(0.18) : Color.secondary.opacity(0.12))
+            Image(systemName: icon)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+        }
+        .frame(width: 28, height: 28)
+    }
+
+    @ViewBuilder
+    private var checkmark: some View {
+        if isSelected {
+            ZStack {
+                Circle()
+                    .fill(Color.accentColor)
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+            .frame(width: 18, height: 18)
+            .transition(.scale.combined(with: .opacity))
+        } else {
+            Circle()
+                .strokeBorder(Color.secondary.opacity(0.4), lineWidth: 1.2)
+                .frame(width: 18, height: 18)
+        }
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .fill(
+                isSelected
+                    ? Color.accentColor.opacity(0.08)
+                    : (isHovered ? Color.secondary.opacity(0.06) : Color.clear)
+            )
+    }
+
+    private var cardBorder: some View {
+        RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .strokeBorder(
+                isSelected ? Color.accentColor.opacity(0.35) : Color.secondary.opacity(0.18),
+                lineWidth: 1
+            )
     }
 }

--- a/Starcat/Features/AI/BatchAIOptionsSheet.swift
+++ b/Starcat/Features/AI/BatchAIOptionsSheet.swift
@@ -1,0 +1,201 @@
+//
+//  BatchAIOptionsSheet.swift
+//  Starcat
+//
+//  HOM-52 - 批量整理启动前的操作选择 Sheet。
+//
+//  模块职责：
+//  - 让用户选择本次要跑哪些 AI 子任务（摘要 / 标签）。
+//  - 让用户决定是否"自动应用推荐标签"+ 设置置信度阈值。
+//  - 显示本次将处理的 repo 数量与简单时长估算。
+//
+//  关键约束：
+//  - 默认值与 dong4j 2026-06-06 评审决议一致：actions=[summary,tags]、autoApply=false、threshold=0.90。
+//  - 置信度滑条仅在 autoApplyTags 打开时显示，避免无谓配置项干扰。
+//  - 启动按钮在 actions 为空 / repo 数为 0 时禁用，避免误触发。
+//
+
+import SwiftUI
+
+struct BatchAIOptionsSheet: View {
+
+    let pendingCount: Int
+    @Binding var options: BatchAIQueueOptions
+    let onCancel: () -> Void
+    let onStart: () -> Void
+
+    /// 平均每 repo 5-10s（依据 RepoAIInsightService 实测），取中位 8s 给用户一个"约 N 分钟"参考。
+    /// 实际进度估算由 BatchAIQueueService.estimatedTimeRemaining 接管。
+    private static let avgSecondsPerRepo: Double = 8.0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+
+            Divider()
+
+            actionsSection
+
+            autoApplySection
+
+            Divider()
+
+            footer
+        }
+        .padding(20)
+        .frame(width: 460)
+    }
+
+    // MARK: - 子视图
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: "sparkles")
+                    .foregroundStyle(.tint)
+                Text("batchAI.options.title")
+                    .font(.headline)
+            }
+            Text(String(format: String(localized: "batchAI.options.subtitleFormat"), pendingCount))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            estimateLabel
+        }
+    }
+
+    @ViewBuilder
+    private var estimateLabel: some View {
+        let seconds = Double(pendingCount) * Self.avgSecondsPerRepo
+        let minutes = max(1, Int((seconds / 60).rounded(.up)))
+        Text(String(format: String(localized: "batchAI.options.estimateFormat"), minutes))
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+    }
+
+    private var actionsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("batchAI.options.actionsLabel")
+                .font(.subheadline.weight(.medium))
+
+            ToggleRow(
+                isOn: actionBinding(for: .summary),
+                title: "batchAI.options.action.summary",
+                subtitle: "batchAI.options.action.summary.desc",
+                systemImage: "doc.text"
+            )
+            ToggleRow(
+                isOn: actionBinding(for: .tags),
+                title: "batchAI.options.action.tags",
+                subtitle: "batchAI.options.action.tags.desc",
+                systemImage: "tag"
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var autoApplySection: some View {
+        let tagsEnabled = options.actions.contains(.tags)
+
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle(isOn: $options.autoApplyTags) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("batchAI.options.autoApply")
+                        .font(.subheadline.weight(.medium))
+                    Text("batchAI.options.autoApply.desc")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .toggleStyle(.switch)
+            .disabled(!tagsEnabled)
+
+            if options.autoApplyTags, tagsEnabled {
+                thresholdSlider
+            }
+        }
+    }
+
+    private var thresholdSlider: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("batchAI.options.threshold")
+                    .font(.caption)
+                Spacer()
+                Text(verbatim: percentString(options.confidenceThreshold))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            Slider(value: $options.confidenceThreshold, in: 0.5...1.0, step: 0.05)
+            Text(String(format: String(localized: "batchAI.options.threshold.hintFormat"), percentString(options.confidenceThreshold)))
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.leading, 28)
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            Button("general.cancel", action: onCancel)
+                .keyboardShortcut(.cancelAction)
+            Button {
+                onStart()
+            } label: {
+                Text(String(format: String(localized: "batchAI.options.startFormat"), pendingCount))
+            }
+            .buttonStyle(.borderedProminent)
+            .keyboardShortcut(.defaultAction)
+            .disabled(!options.isValidForStart || pendingCount == 0)
+        }
+    }
+
+    // MARK: - 辅助
+
+    /// 把 actions Set 投影成单个 Action 的 Toggle binding。
+    /// Toggle 切换时 add/remove 即可，逻辑短小不抽函数。
+    private func actionBinding(for action: BatchAIAction) -> Binding<Bool> {
+        Binding(
+            get: { options.actions.contains(action) },
+            set: { newValue in
+                if newValue {
+                    options.actions.insert(action)
+                } else {
+                    options.actions.remove(action)
+                }
+            }
+        )
+    }
+
+    private func percentString(_ v: Double) -> String {
+        "\(Int((v * 100).rounded()))%"
+    }
+}
+
+// MARK: - ToggleRow
+
+/// "操作选择 Sheet"内复用的 Toggle 行：左图标 + 标题 + 副标题 + 右开关。
+/// 不外迁到 Components/，因为只在本 sheet 使用且语义紧耦合。
+private struct ToggleRow: View {
+    let isOn: Binding<Bool>
+    let title: LocalizedStringKey
+    let subtitle: LocalizedStringKey
+    let systemImage: String
+
+    var body: some View {
+        Toggle(isOn: isOn) {
+            HStack(spacing: 10) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 16))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 22)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title).font(.subheadline)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .toggleStyle(.switch)
+    }
+}

--- a/Starcat/Features/AI/BatchAIOptionsSheet.swift
+++ b/Starcat/Features/AI/BatchAIOptionsSheet.swift
@@ -19,7 +19,9 @@
 //  - 改用 **可点击卡片 + 圆形 checkmark**：整行点击切换，圆形勾选标记替代 toggle，
 //    视觉重量更轻。选中态用 tint 淡色背景 + 描边明确反馈。
 //  - hover 反馈复用项目共享 `PressableHover`，与详情页可点击元素一致。
-//  - 自动应用 / 阈值滑条作为"标签"的子设置缩进展示，依赖关系清晰。
+//  - 自动应用作为"标签"的子设置：未选标签时整卡 disabled；阈值滑条仅在
+//    autoApply 打开时显示，与上方 OptionCard 左右对齐（不再额外缩进，避免
+//    左缘错落破坏视觉节奏）。
 //
 
 import SwiftUI
@@ -170,7 +172,10 @@ struct BatchAIOptionsSheet: View {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(Color.secondary.opacity(0.06))
         )
-        .padding(.leading, 36)  // 视觉上缩进，体现"自动应用"的子设置层级
+        // 2026-06-07 dong4j 反馈：之前 .padding(.leading, 36) 缩进导致与上方
+        // OptionCard 左缘不齐，看着像"漏了一块"。改为左右对齐。
+        // 父子层级靠"出现时机（autoApply 开了才显示）+ 浅灰圆角背景 + 紧贴上方"
+        // 已经能让用户理解依赖关系，不必再靠物理缩进强调。
     }
 
     // MARK: - Footer

--- a/Starcat/Features/AI/BatchAIQueueModels.swift
+++ b/Starcat/Features/AI/BatchAIQueueModels.swift
@@ -1,0 +1,157 @@
+//
+//  BatchAIQueueModels.swift
+//  Starcat
+//
+//  HOM-52 批量未分类仓库 AI 整理 - 数据模型层。
+//
+//  模块职责：
+//  - 定义"批量 AI 整理"队列中的单元 Job、状态机、本次任务配置 Options。
+//  - 作为 BatchAIQueueService（状态机执行者）与 SwiftUI（状态展示者）之间的稳定边界。
+//
+//  关键约束：
+//  - Job 是**会话级**对象：纯内存持有，不落库。详细理由见 BatchAIQueueService 文件头。
+//    （已有 AI 摘要会命中 ai_summaries 表，所以重启后再次处理也不会浪费 AI 配额。）
+//  - 状态枚举与 "ignored" 的引入：dong4j 2026-06-06 16:21 评审决议——
+//    当开启"自动应用标签"时，置信度低于阈值的推荐应被**自动忽略**（不计入失败、不重试）。
+//    `ignored` 与 `failed` 在 UX 上必须区分，否则用户会误以为 AI 失败率虚高。
+//  - 操作集 Options.actions 用 Set<Action> 保证多选幂等；UI 默认勾选「摘要 + 标签」。
+//
+
+import Foundation
+
+// MARK: - BatchAIJobStatus
+
+/// 队列中单个 repo 的处理状态机。
+///
+/// 状态流转：
+/// ```
+///                     ┌──> .completed    （应用了 N 个标签 / 摘要写入成功）
+/// .queued ─> .processing ──> .ignored     （AI 返回的所有标签都低于置信度阈值）
+///                     │
+///                     └──> .failed        （重试 N 次仍失败：网络/AI Key/JSON 解析等）
+/// ```
+///
+/// 注意：
+/// - `ignored` 与 `failed` 是互斥终态，UI 用不同颜色 / 文案表达。
+/// - `failed` 才计入"失败计数 + 触发重试"；`ignored` 不算失败。
+/// - `queued` 时未做任何调用，可以被用户在面板中删除或整体 cancel。
+enum BatchAIJobStatus: String, Codable, Equatable, Sendable {
+    case queued
+    case processing
+    case completed
+    case ignored
+    case failed
+}
+
+// MARK: - BatchAIJob
+
+/// 队列中单个 repo 的执行记录。
+///
+/// `id` 用 `repoId` 直接当主键：同一仓库不允许在队列中出现两次（去重在 enqueue 处保证）。
+/// 这样 SwiftUI ForEach 用 `\.id` 即可稳定 diff，无需额外 UUID。
+struct BatchAIJob: Identifiable, Equatable, Sendable {
+
+    /// 复用 GitHub repo id 作为唯一键（队列内 repo 唯一）。
+    var id: Int64 { repoId }
+
+    let repoId: Int64
+    /// 仅用于 UI 显示，避免每次渲染都回查 Repository。
+    let repoFullName: String
+
+    var status: BatchAIJobStatus = .queued
+
+    /// 已经发起的尝试次数（不含尚未开始的本次）。失败重试上限见 BatchAIQueueOptions.maxRetries。
+    var attempts: Int = 0
+
+    /// 失败原因（status == .failed 时填）。Markdown / 系统通知都会引用。
+    var errorMessage: String?
+
+    /// 成功应用的标签名（status == .completed 时填）。
+    /// 用 [String] 而非 [Tag]，避免 ViewModel 跨线程持有 GRDB 实体。
+    var appliedTagNames: [String] = []
+
+    /// 因低于置信度阈值被忽略的标签（status == .ignored 时填）。
+    /// 仍保留 `(name, confidence)` 二元组以便 UI 提示"X% < 阈值 Y%"。
+    var ignoredTagsBelowThreshold: [(name: String, confidence: Double)] = []
+
+    /// 进入终态的时间戳，便于按"最近完成"排序。
+    var finishedAt: Date?
+
+    /// 是否生成了 AI 摘要（用于 UI 区分"只跑了标签"和"摘要 + 标签都跑了"）。
+    var didGenerateSummary: Bool = false
+
+    init(repoId: Int64, repoFullName: String) {
+        self.repoId = repoId
+        self.repoFullName = repoFullName
+    }
+
+    // `ignoredTagsBelowThreshold` 含元组数组，Equatable 需要手写。
+    static func == (lhs: BatchAIJob, rhs: BatchAIJob) -> Bool {
+        guard lhs.repoId == rhs.repoId,
+              lhs.repoFullName == rhs.repoFullName,
+              lhs.status == rhs.status,
+              lhs.attempts == rhs.attempts,
+              lhs.errorMessage == rhs.errorMessage,
+              lhs.appliedTagNames == rhs.appliedTagNames,
+              lhs.finishedAt == rhs.finishedAt,
+              lhs.didGenerateSummary == rhs.didGenerateSummary,
+              lhs.ignoredTagsBelowThreshold.count == rhs.ignoredTagsBelowThreshold.count
+        else { return false }
+        for (l, r) in zip(lhs.ignoredTagsBelowThreshold, rhs.ignoredTagsBelowThreshold) {
+            if l.name != r.name || l.confidence != r.confidence { return false }
+        }
+        return true
+    }
+}
+
+// MARK: - BatchAIAction
+
+/// 本次批量整理需要执行的子任务。
+///
+/// 之所以拆成 Set 而不是布尔位字段：
+/// - 后续扩展（如新增"AI 自动分类"）只需 case 增加一项，不破坏旧序列化。
+/// - UI 多选 Toggle 与 Set 天然对齐，且预设勾选集合可由 Set 字面量表达。
+enum BatchAIAction: String, CaseIterable, Codable, Hashable, Sendable {
+    /// 生成 AI 摘要（写入 ai_summaries 表）。
+    case summary
+    /// 推荐并应用 / 暂存标签（依 Options.autoApplyTags 决定是否落库）。
+    case tags
+}
+
+// MARK: - BatchAIQueueOptions
+
+/// 单次启动批量整理时的执行配置。
+///
+/// 默认值与 dong4j 2026-06-06 评审一致：
+/// - actions = [.summary, .tags]
+/// - autoApplyTags = false（默认走详情页确认流，避免新用户误产生大量未确认标签）
+/// - confidenceThreshold = 0.90（dong4j 16:22 明确要求默认 90%）
+/// - maxRetries = 3（任务描述明确）
+struct BatchAIQueueOptions: Equatable, Sendable {
+
+    /// 本次要跑哪些 AI 子任务。空集合视为无效（UI 应禁用启动按钮）。
+    var actions: Set<BatchAIAction> = [.summary, .tags]
+
+    /// 是否自动应用 AI 推荐的标签（不弹确认框）。
+    ///
+    /// 设计取舍：默认 false。这是"破坏性 + 不可逆"的批量写入，
+    /// 用户首次大批量整理时主动开启，平时小批量保持手动确认更安全。
+    var autoApplyTags: Bool = false
+
+    /// 自动应用标签时的置信度阈值（0.0 ~ 1.0）。
+    ///
+    /// 仅当 `autoApplyTags == true` 时生效；低于阈值的标签会进入 ignored 桶并展示原因。
+    /// 默认 0.90，对应 dong4j 评审决议。
+    var confidenceThreshold: Double = 0.90
+
+    /// 失败重试上限。
+    ///
+    /// 区分两类错误：
+    /// - **可重试**：网络超时 / 5xx / 解析失败 → 重试至 maxRetries
+    /// - **不可重试**：API Key 缺失 / 401 等鉴权错误 → 直接 failed，不消耗重试次数
+    /// 不可重试错误的判别由 BatchAIQueueService.isPermanentError 实现。
+    var maxRetries: Int = 3
+
+    /// 至少要选一个子任务才能启动队列。
+    var isValidForStart: Bool { !actions.isEmpty }
+}

--- a/Starcat/Features/AI/BatchAIQueuePanel.swift
+++ b/Starcat/Features/AI/BatchAIQueuePanel.swift
@@ -1,0 +1,316 @@
+//
+//  BatchAIQueuePanel.swift
+//  Starcat
+//
+//  HOM-52 - 批量整理进度浮动面板。
+//
+//  模块职责：
+//  - 展示当前批次的总进度、剩余时间、当前 repo、单 job 状态列表（可滚动）。
+//  - 提供暂停 / 继续 / 取消 / 单项重试 / 重试全部 控件。
+//  - 完成后允许用户关闭并 reset 队列。
+//
+//  关键约束：
+//  - 状态列表用 ScrollView + LazyVStack 强行限定最大高度 320pt，避免"处理 1000 项时 UI 爆炸"
+//    （dong4j 2026-06-06 16:13 评审第 3 条）。
+//  - 面板用 .sheet 承载：关闭面板不会停止队列（队列继续在后台跑，再开面板可恢复观察），
+//    对应"支持后台继续"验收点。
+//  - 区分三档终态视觉：completed=绿色 / ignored=灰色 / failed=红色，搭配文字补充原因。
+//
+
+import SwiftUI
+
+struct BatchAIQueuePanel: View {
+
+    @Bindable var service: BatchAIQueueService
+
+    /// 调用方提供的关闭回调（关闭 sheet）。
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            progressSummary
+            Divider()
+            jobList
+                .frame(minHeight: 200, maxHeight: 320)
+            if service.failedCount > 0 {
+                Divider()
+                failedFooter
+            }
+        }
+        .frame(width: 520)
+        .padding(0)
+    }
+
+    // MARK: - 顶部 header（标题 + 操作按钮）
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "sparkles")
+                .foregroundStyle(.tint)
+            Text("batchAI.panel.title")
+                .font(.headline)
+            Spacer()
+            if !service.isFinished, service.isRunning {
+                if service.isPaused {
+                    Button {
+                        service.resume()
+                    } label: {
+                        Label("batchAI.panel.resume", systemImage: "play.fill")
+                            .labelStyle(.iconOnly)
+                    }
+                    .help("batchAI.panel.resume")
+                } else {
+                    Button {
+                        service.pause()
+                    } label: {
+                        Label("batchAI.panel.pause", systemImage: "pause.fill")
+                            .labelStyle(.iconOnly)
+                    }
+                    .help("batchAI.panel.pause")
+                }
+                Button(role: .destructive) {
+                    service.cancel()
+                } label: {
+                    Label("batchAI.panel.cancel", systemImage: "stop.fill")
+                        .labelStyle(.iconOnly)
+                }
+                .help("batchAI.panel.cancel")
+            }
+            Button {
+                if service.isFinished {
+                    service.reset()
+                }
+                onClose()
+            } label: {
+                Label("general.close", systemImage: "xmark")
+                    .labelStyle(.iconOnly)
+            }
+            .help("general.close")
+            .keyboardShortcut(.cancelAction)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    // MARK: - 进度摘要
+
+    private var progressSummary: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 6) {
+                Text(String(format: String(localized: "batchAI.panel.progressFormat"), service.finishedCount, service.totalCount))
+                    .font(.subheadline.weight(.medium))
+                    .monospacedDigit()
+                if service.isPaused {
+                    Text("batchAI.panel.paused")
+                        .font(.caption)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.yellow.opacity(0.2), in: Capsule())
+                        .foregroundStyle(.orange)
+                }
+                Spacer()
+                if let remaining = service.estimatedTimeRemaining, !service.isFinished, remaining > 0 {
+                    Label {
+                        Text(formattedRemaining(remaining))
+                            .font(.caption.monospacedDigit())
+                    } icon: {
+                        Image(systemName: "clock")
+                            .font(.caption2)
+                    }
+                    .foregroundStyle(.secondary)
+                }
+            }
+            ProgressView(value: progressFraction)
+                .progressViewStyle(.linear)
+                .tint(service.failedCount > 0 ? .orange : .accentColor)
+            currentJobLabel
+            countersRow
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private var currentJobLabel: some View {
+        if let currentId = service.currentJobId,
+           let currentJob = service.jobs.first(where: { $0.repoId == currentId }) {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text(String(format: String(localized: "batchAI.panel.currentFormat"), currentJob.repoFullName))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        } else if service.isFinished {
+            Label("batchAI.panel.finished", systemImage: "checkmark.seal.fill")
+                .font(.caption)
+                .foregroundStyle(.green)
+        }
+    }
+
+    private var countersRow: some View {
+        HStack(spacing: 14) {
+            counter(label: "batchAI.panel.counter.completed", count: service.completedCount, color: .green)
+            if service.ignoredCount > 0 {
+                counter(label: "batchAI.panel.counter.ignored", count: service.ignoredCount, color: .gray)
+            }
+            if service.failedCount > 0 {
+                counter(label: "batchAI.panel.counter.failed", count: service.failedCount, color: .red)
+            }
+            Spacer()
+        }
+    }
+
+    private func counter(label: LocalizedStringKey, count: Int, color: Color) -> some View {
+        HStack(spacing: 3) {
+            Circle().fill(color).frame(width: 6, height: 6)
+            Text(label).font(.caption)
+            Text(verbatim: "\(count)").font(.caption.monospacedDigit())
+        }
+        .foregroundStyle(.secondary)
+    }
+
+    // MARK: - 状态列表（可滚动）
+
+    private var jobList: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(service.jobs) { job in
+                    JobRow(job: job, onRetry: {
+                        service.retry(jobId: job.repoId)
+                    })
+                    Divider()
+                }
+            }
+        }
+        .background(Color(nsColor: .textBackgroundColor).opacity(0.4))
+    }
+
+    // MARK: - 失败底栏
+
+    private var failedFooter: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(String(format: String(localized: "batchAI.panel.failedSummaryFormat"), service.failedCount))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button("batchAI.panel.retryAll") {
+                service.retryAllFailed()
+            }
+            .controlSize(.small)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.orange.opacity(0.08))
+    }
+
+    // MARK: - 派生
+
+    private var progressFraction: Double {
+        guard service.totalCount > 0 else { return 0 }
+        return Double(service.finishedCount) / Double(service.totalCount)
+    }
+
+    private func formattedRemaining(_ seconds: TimeInterval) -> String {
+        if seconds < 60 {
+            return String(format: String(localized: "batchAI.panel.remainingSecondsFormat"), Int(seconds.rounded()))
+        }
+        let minutes = Int((seconds / 60).rounded())
+        return String(format: String(localized: "batchAI.panel.remainingMinutesFormat"), minutes)
+    }
+}
+
+// MARK: - JobRow
+
+/// 单 job 行：图标 + repo 名 + 状态文本 + 右侧 retry 按钮（仅 failed 显示）。
+///
+/// 性能：用 LazyVStack 懒加载，行内只渲染轻量元素（无 markdown / 图像）。
+/// 大批次（1000+）滚动时也只渲染可视行，不会爆 CPU。
+private struct JobRow: View {
+    let job: BatchAIJob
+    let onRetry: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            statusIcon
+                .frame(width: 16, height: 16)
+                .padding(.top, 1)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: job.repoFullName)
+                    .font(.subheadline.monospaced())
+                    .lineLimit(1)
+                if let detail = detailText {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer(minLength: 6)
+
+            if job.status == .failed {
+                Button {
+                    onRetry()
+                } label: {
+                    Text("batchAI.panel.retry")
+                }
+                .controlSize(.small)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch job.status {
+        case .queued:
+            Image(systemName: "circle")
+                .foregroundStyle(.tertiary)
+        case .processing:
+            ProgressView()
+                .controlSize(.small)
+        case .completed:
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .ignored:
+            Image(systemName: "minus.circle.fill")
+                .foregroundStyle(.gray)
+        case .failed:
+            Image(systemName: "xmark.octagon.fill")
+                .foregroundStyle(.red)
+        }
+    }
+
+    /// 副标题：根据状态拼接（已应用标签 / 被忽略的标签 / 错误信息）。
+    private var detailText: String? {
+        switch job.status {
+        case .queued:
+            return nil
+        case .processing:
+            return String(localized: "batchAI.panel.row.processing")
+        case .completed:
+            if !job.appliedTagNames.isEmpty {
+                let tagsStr = job.appliedTagNames.prefix(5).joined(separator: ", ")
+                return String(format: String(localized: "batchAI.panel.row.appliedTagsFormat"), tagsStr)
+            }
+            return job.didGenerateSummary
+                ? String(localized: "batchAI.panel.row.summaryOnly")
+                : String(localized: "batchAI.panel.row.completedNoTags")
+        case .ignored:
+            let names = job.ignoredTagsBelowThreshold.prefix(3).map { suggestion in
+                "\(suggestion.name)(\(Int((suggestion.confidence * 100).rounded()))%)"
+            }.joined(separator: ", ")
+            return String(format: String(localized: "batchAI.panel.row.ignoredFormat"), names)
+        case .failed:
+            return job.errorMessage ?? String(localized: "batchAI.panel.row.failedUnknown")
+        }
+    }
+}

--- a/Starcat/Features/AI/BatchAIQueuePanel.swift
+++ b/Starcat/Features/AI/BatchAIQueuePanel.swift
@@ -77,6 +77,8 @@ struct BatchAIQueuePanel: View {
                         .labelStyle(.iconOnly)
                 }
                 .help("batchAI.panel.cancel")
+                // 用户已经点过取消但 in-flight job 还没跑完时禁用，避免重复点击让人困惑。
+                .disabled(service.isCancelling)
             }
             Button {
                 if service.isFinished {
@@ -102,7 +104,14 @@ struct BatchAIQueuePanel: View {
                 Text(String(format: String(localized: "batchAI.panel.progressFormat"), service.finishedCount, service.totalCount))
                     .font(.subheadline.weight(.medium))
                     .monospacedDigit()
-                if service.isPaused {
+                if service.isCancelling {
+                    Text("batchAI.panel.cancelling")
+                        .font(.caption)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.red.opacity(0.18), in: Capsule())
+                        .foregroundStyle(.red)
+                } else if service.isPaused {
                     Text("batchAI.panel.paused")
                         .font(.caption)
                         .padding(.horizontal, 6)
@@ -134,7 +143,17 @@ struct BatchAIQueuePanel: View {
 
     @ViewBuilder
     private var currentJobLabel: some View {
-        if let currentId = service.currentJobId,
+        if service.isCancelling {
+            // 取消已生效但当前 AI 调用未结束：明确告诉用户在等什么。
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("batchAI.panel.cancellingDetail")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(1)
+            }
+        } else if let currentId = service.currentJobId,
            let currentJob = service.jobs.first(where: { $0.repoId == currentId }) {
             HStack(spacing: 6) {
                 ProgressView()

--- a/Starcat/Features/AI/BatchAIQueueService.swift
+++ b/Starcat/Features/AI/BatchAIQueueService.swift
@@ -1,0 +1,417 @@
+//
+//  BatchAIQueueService.swift
+//  Starcat
+//
+//  HOM-52 批量未分类仓库 AI 整理 - 队列状态机 + UI 可观察对象。
+//
+//  模块职责：
+//  - 维护单一全局批量整理队列（同时只跑一个批次，避免 AI 配额尖刺）。
+//  - 串行处理 jobs：取下一个 queued → 调 RepoAIInsightService.generateInsight
+//    → 按 Options 落库标签 → 写终态。
+//  - 暴露 @Observable 状态供 BatchAIQueuePanel / 入口 Banner 直接绑定。
+//
+//  关键约束：
+//  - **会话内存级**：队列、进度、失败记录不落库。重启 app 即清空。
+//    设计理由：(1) 已生成的 AI 摘要存在 ai_summaries 表，重启后再次整理会命中 cache
+//    不重复消耗配额；(2) 落库要新增 batch_ai_jobs 表 + 迁移 + Repository，
+//    与 dong4j 强调的"最小代码"冲突；(3) 用户预期的"后台继续"指 panel 关闭后仍跑，
+//    而非跨进程恢复——若未来真有需求，再独立 V8 迁移即可。
+//  - **串行执行**：一次只处理一个 repo。AI provider 多数有速率限制，且串行能让
+//    "暂停"语义干净（当前 job 跑完即停）。如需提速，后续可加 concurrency 配置。
+//  - **重试不可重试错误甄别**：API Key 缺失 / Provider 缺失这类配置错误**不消耗重试次数**——
+//    用户没改配置之前永远不会成功，重试只会让 panel 失败计数误增。
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class BatchAIQueueService {
+
+    // MARK: - 可观察状态（@Observable 自动生成 didSet / willSet 跟踪）
+
+    /// 当前队列中的所有 jobs（含已完成 / 已失败 / 已忽略 / 仍在排队）。
+    /// UI 用 ForEach 直接绑定。新批次开始时整个数组被替换（不保留上一轮记录）。
+    private(set) var jobs: [BatchAIJob] = []
+
+    /// 本次启动时的执行配置。空表示当前没有进行中的批次。
+    private(set) var options: BatchAIQueueOptions?
+
+    /// 是否正在处理（取出 job → 调 AI → 落库 的整个生命周期内为 true）。
+    /// 进入暂停态时为 false，但 jobs 仍保留以便用户继续。
+    private(set) var isRunning: Bool = false
+
+    /// 是否被用户暂停。`isRunning && !isPaused` 才会拉下一个 job。
+    private(set) var isPaused: Bool = false
+
+    /// 当前正在处理的 job repoId（用于 UI 高亮当前行）。
+    private(set) var currentJobId: Int64?
+
+    /// 本次批次的开始时刻，用于估算剩余时间（已用时 / 完成数 → 平均耗时）。
+    private(set) var startedAt: Date?
+
+    /// 用户主动取消标志位：在 processNext 循环开始处轮询，命中即跳出。
+    private var cancelRequested: Bool = false
+
+    // MARK: - 依赖（按 AppDependencies 装配顺序注入）
+
+    private let insightService: RepoAIInsightService
+    private let tagRepository: any TagRepositoryProtocol
+    private let repoTagRepository: any RepoTagRepositoryProtocol
+    private let aiSummaryRepository: any AISummaryRepositoryProtocol
+
+    /// 标签应用后通知外部刷新 Sidebar 计数 / 当前列表。
+    /// 设计上用闭包而非 NotificationCenter，避免跨模块字符串通知名飘移。
+    var onTagsChanged: (() -> Void)?
+
+    init(
+        insightService: RepoAIInsightService,
+        tagRepository: any TagRepositoryProtocol,
+        repoTagRepository: any RepoTagRepositoryProtocol,
+        aiSummaryRepository: any AISummaryRepositoryProtocol
+    ) {
+        self.insightService = insightService
+        self.tagRepository = tagRepository
+        self.repoTagRepository = repoTagRepository
+        self.aiSummaryRepository = aiSummaryRepository
+    }
+
+    // MARK: - 派生状态（panel UI 用）
+
+    var totalCount: Int { jobs.count }
+    var completedCount: Int { jobs.lazy.filter { $0.status == .completed }.count }
+    var failedCount: Int { jobs.lazy.filter { $0.status == .failed }.count }
+    var ignoredCount: Int { jobs.lazy.filter { $0.status == .ignored }.count }
+    var queuedCount: Int { jobs.lazy.filter { $0.status == .queued }.count }
+    var finishedCount: Int { completedCount + failedCount + ignoredCount }
+
+    /// 全部 job 都进入终态时认为本次批次结束。
+    var isFinished: Bool { !jobs.isEmpty && finishedCount == jobs.count }
+
+    /// 失败列表（按时间倒序），用于 UI 顶部"X 个失败"红色提示与"重试全部"按钮。
+    var failedJobs: [BatchAIJob] {
+        jobs.filter { $0.status == .failed }
+    }
+
+    /// 估算剩余时间（秒）。
+    ///
+    /// 公式：已用时 / 完成数 × 剩余数。仅当 finishedCount >= 1 才有意义，
+    /// 否则返回 nil。AI 调用耗时方差大，UI 端展示用模糊措辞"约 N 分钟"。
+    var estimatedTimeRemaining: TimeInterval? {
+        guard let startedAt, finishedCount > 0 else { return nil }
+        let elapsed = Date().timeIntervalSince(startedAt)
+        let avgPerJob = elapsed / Double(finishedCount)
+        let remaining = totalCount - finishedCount
+        guard remaining > 0 else { return 0 }
+        return avgPerJob * Double(remaining)
+    }
+
+    // MARK: - 公共 API
+
+    /// 启动一批新的整理任务。
+    ///
+    /// 行为：清掉上一批次的 jobs（即使是已完成的）→ 把传入 repos 全部入队 → 启动循环。
+    /// 如果当前正在跑且未结束，会被拒绝（调用方应先 cancel）。
+    func start(repos: [Repo], options: BatchAIQueueOptions) {
+        guard !isRunning else {
+            AppLog.ai.warning("[batch-ai] start() ignored: already running")
+            return
+        }
+        guard options.isValidForStart, !repos.isEmpty else {
+            AppLog.ai.warning("[batch-ai] start() ignored: invalid options or empty repo list")
+            return
+        }
+        self.options = options
+        self.jobs = repos.map { BatchAIJob(repoId: $0.id, repoFullName: $0.fullName) }
+        self.repoCache = Dictionary(uniqueKeysWithValues: repos.map { ($0.id, $0) })
+        self.isPaused = false
+        self.isRunning = true
+        self.cancelRequested = false
+        self.startedAt = Date()
+        self.currentJobId = nil
+        AppLog.ai.notice("[batch-ai] start: count=\(repos.count, privacy: .public), autoApplyTags=\(options.autoApplyTags, privacy: .public), threshold=\(options.confidenceThreshold, privacy: .public)")
+        Task { await runLoop() }
+    }
+
+    /// 暂停。当前 job 跑完即停；不杀进行中的 AI 调用（强中断会触发 partial 状态难处理）。
+    func pause() {
+        guard isRunning, !isPaused else { return }
+        isPaused = true
+        AppLog.ai.notice("[batch-ai] paused")
+    }
+
+    /// 继续。
+    func resume() {
+        guard isRunning, isPaused else { return }
+        isPaused = false
+        AppLog.ai.notice("[batch-ai] resumed")
+        Task { await runLoop() }
+    }
+
+    /// 取消整批：标记 cancel → 不杀当前 in-flight job → 标记 isRunning = false。
+    func cancel() {
+        guard isRunning else { return }
+        cancelRequested = true
+        isPaused = false
+        AppLog.ai.notice("[batch-ai] cancel requested")
+    }
+
+    /// 重置：清空全部 jobs / options / 进度。
+    /// 调用方场景：用户点 panel 的"关闭"按钮且已 finished，或新开一批整理前。
+    func reset() {
+        guard !isRunning else { return }
+        jobs = []
+        options = nil
+        startedAt = nil
+        currentJobId = nil
+        cancelRequested = false
+    }
+
+    /// 重试单个失败的 job。
+    /// - 把 attempts 归零、status 重置为 queued。
+    /// - 如果当前循环不在跑（已 finished），重新启动循环。
+    func retry(jobId: Int64) {
+        guard let idx = jobs.firstIndex(where: { $0.repoId == jobId }) else { return }
+        guard jobs[idx].status == .failed else { return }
+        jobs[idx].status = .queued
+        jobs[idx].attempts = 0
+        jobs[idx].errorMessage = nil
+        jobs[idx].finishedAt = nil
+        if !isRunning {
+            isRunning = true
+            isPaused = false
+            cancelRequested = false
+            Task { await runLoop() }
+        }
+    }
+
+    /// 重试全部失败。批量版本，避免 UI 端循环触发 N 次 runLoop。
+    func retryAllFailed() {
+        var touched = false
+        for idx in jobs.indices where jobs[idx].status == .failed {
+            jobs[idx].status = .queued
+            jobs[idx].attempts = 0
+            jobs[idx].errorMessage = nil
+            jobs[idx].finishedAt = nil
+            touched = true
+        }
+        if touched, !isRunning {
+            isRunning = true
+            isPaused = false
+            cancelRequested = false
+            Task { await runLoop() }
+        }
+    }
+
+    // MARK: - 主循环
+
+    /// 串行拉取 queued 的 job 处理，直到全部进入终态、被暂停或被取消。
+    ///
+    /// 注意：方法本身是 async；start / resume / retry 都 fire-and-forget 调用一次，
+    /// 不重入（循环开始时若已无 queued 直接退出）。多次触发只会再 enter 一次循环但
+    /// 立刻退出，不会产生并发。
+    private func runLoop() async {
+        guard let options else { return }
+
+        while true {
+            if cancelRequested {
+                // 取消：把所有 queued 标 failed("用户取消")？不——保留 queued 状态，
+                // 让用户能在终止后继续。取消只意味着退出循环。
+                break
+            }
+            if isPaused { break }
+            guard let nextIdx = jobs.firstIndex(where: { $0.status == .queued }) else {
+                break
+            }
+
+            currentJobId = jobs[nextIdx].repoId
+            jobs[nextIdx].status = .processing
+            jobs[nextIdx].attempts += 1
+            let jobSnapshot = jobs[nextIdx]
+
+            do {
+                let result = try await processSingle(jobId: jobSnapshot.repoId, options: options)
+                await applyResult(jobId: jobSnapshot.repoId, result: result, options: options)
+            } catch {
+                handleFailure(jobId: jobSnapshot.repoId, error: error, options: options)
+            }
+
+            currentJobId = nil
+
+            // 每完成一个 job 就让出主线程，让 UI 渲染 panel 进度
+            await Task.yield()
+        }
+
+        // 循环退出：若全部终态则关掉 isRunning；否则保留状态等用户 resume / cancel。
+        if isFinished || cancelRequested || jobs.allSatisfy({ $0.status != .queued }) {
+            isRunning = false
+            currentJobId = nil
+            if isFinished {
+                AppLog.ai.notice("[batch-ai] finished: completed=\(self.completedCount, privacy: .public), ignored=\(self.ignoredCount, privacy: .public), failed=\(self.failedCount, privacy: .public)")
+            }
+        }
+    }
+
+    // MARK: - 单 job 处理
+
+    /// 处理单个 repo 的执行结果（成功路径携带的产出）。
+    private struct JobOutcome {
+        var insight: RepoAIInsightGeneration
+        var repo: Repo
+        var existingTagHints: [String]
+    }
+
+    /// 调 RepoAIInsightService 拉取摘要 / 标签建议；本方法**不写库**，
+    /// 决策（写哪些标签 / 标 ignored）放在 applyResult 里。
+    private func processSingle(jobId: Int64, options: BatchAIQueueOptions) async throws -> JobOutcome {
+        // 通过 insightService 拿不到原 Repo，HomeView 进入 batch 前已经把 repos 传给 start()，
+        // jobs 里只存了 repoId + fullName。这里我们需要 Repo（generateInsight 要 description / topics）。
+        // 折中方案：再从 RepoTagRepository 借用全表标签做 hints（已有 fetchAll API），
+        // 而 Repo 本身改由调用方 enqueue 时打包好——但为了不污染 BatchAIJob 字段过宽，
+        // 这里改成 enqueue 时同时持有 [Repo]。
+        guard let repo = repoCache[jobId] else {
+            throw RepoAIInsightError.invalidJSON  // 复用现有 error 类型；不应发生
+        }
+
+        // 拉一次"现有标签 + 计数"作为 prompt 提示。
+        // 只有 includeTags 时才有意义；避免无谓查询。
+        let hints: [String]
+        if options.actions.contains(.tags) {
+            let allTags = (try? await tagRepository.fetchAll()) ?? []
+            // 按 sortOrder 已经倒序，前 50 个最常用的足够引导 AI 复用。
+            hints = allTags.prefix(50).map(\.name)
+        } else {
+            hints = []
+        }
+
+        let insight = try await insightService.generateInsight(
+            for: repo,
+            existingTagHints: hints,
+            includeSummary: options.actions.contains(.summary),
+            includeTags: options.actions.contains(.tags)
+        )
+        return JobOutcome(insight: insight, repo: repo, existingTagHints: hints)
+    }
+
+    /// 把 processSingle 的产出按 Options 落库 + 写 job 终态。
+    ///
+    /// async 而非 fire-and-forget：主循环必须等"落库 + 写终态"全部完成，
+    /// 否则下一轮 currentJobId 切换时，前一个 job 仍停在 .processing，UI 出现"两个 processing"假象。
+    private func applyResult(jobId: Int64, result: JobOutcome, options: BatchAIQueueOptions) async {
+        guard let idx = jobs.firstIndex(where: { $0.repoId == jobId }) else { return }
+
+        let suggestions = result.insight.insight.suggestedTags
+        let didSummary = options.actions.contains(.summary)
+        let didTags = options.actions.contains(.tags)
+
+        // 标签子分支：
+        // - 没勾选标签 → 直接 completed（summary 已写）。
+        // - 勾选 + autoApply=true → 按置信度阈值过滤后落库；全部低于阈值 → ignored；否则 completed。
+        // - 勾选 + autoApply=false → 标签建议留在 ai_summaries 缓存里，由用户后续在详情页"AI 标签确认"流应用。
+        //   这种情况 status = completed（任务本身没失败，只是不自动写库）。
+        if didTags, options.autoApplyTags {
+            let belowThreshold = suggestions.filter { $0.confidence < options.confidenceThreshold }
+            let aboveThreshold = suggestions.filter { $0.confidence >= options.confidenceThreshold }
+
+            if aboveThreshold.isEmpty, !suggestions.isEmpty {
+                jobs[idx].status = .ignored
+                jobs[idx].ignoredTagsBelowThreshold = belowThreshold.map { ($0.name, $0.confidence) }
+                jobs[idx].didGenerateSummary = didSummary
+                jobs[idx].finishedAt = Date()
+                return
+            }
+
+            let appliedNames = await applyTagsToRepo(repoId: jobId, suggestions: aboveThreshold)
+            guard let idx2 = jobs.firstIndex(where: { $0.repoId == jobId }) else { return }
+            jobs[idx2].appliedTagNames = appliedNames
+            jobs[idx2].ignoredTagsBelowThreshold = belowThreshold.map { ($0.name, $0.confidence) }
+            jobs[idx2].didGenerateSummary = didSummary
+            jobs[idx2].finishedAt = Date()
+            jobs[idx2].status = .completed
+            if !appliedNames.isEmpty {
+                onTagsChanged?()
+            }
+        } else {
+            jobs[idx].didGenerateSummary = didSummary
+            jobs[idx].finishedAt = Date()
+            jobs[idx].status = .completed
+        }
+    }
+
+    /// 把通过阈值过滤的建议落库为 repo_tags 关联。
+    /// 重复使用 RepoAIInsightViewModel 的 findOrCreate 模式：先按 name 查找，
+    /// 不存在则新建一个最小 Tag（无颜色、默认图标）。
+    private func applyTagsToRepo(repoId: Int64, suggestions: [AITagSuggestion]) async -> [String] {
+        var applied: [String] = []
+        for suggestion in suggestions {
+            let normalized = suggestion.name
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            guard !normalized.isEmpty else { continue }
+            do {
+                let tag = try await findOrCreateTag(named: normalized)
+                try await repoTagRepository.addTag(repoId: repoId, tagId: tag.id)
+                applied.append(normalized)
+            } catch {
+                AppLog.ai.error("[batch-ai] apply tag failed: repo=\(repoId, privacy: .public), tag=\(normalized, privacy: .public), error=\(error.localizedDescription, privacy: .public)")
+            }
+        }
+        return applied
+    }
+
+    private func findOrCreateTag(named name: String) async throws -> Tag {
+        if let existing = try await tagRepository.findByName(name) {
+            return existing
+        }
+        let now = ISO8601DateFormatter.shared.string(from: Date())
+        let tag = Tag(
+            id: UUID().uuidString,
+            name: name,
+            color: nil,
+            icon: "tag",
+            sortOrder: 0,
+            isPreset: false,
+            parentId: nil,
+            createdAt: now,
+            updatedAt: now
+        )
+        try await tagRepository.create(tag)
+        return tag
+    }
+
+    /// 处理单个 job 的失败：分流"重试" vs "终态失败"。
+    private func handleFailure(jobId: Int64, error: Error, options: BatchAIQueueOptions) {
+        guard let idx = jobs.firstIndex(where: { $0.repoId == jobId }) else { return }
+
+        let message = error.localizedDescription
+        AppLog.ai.error("[batch-ai] job failed: repo=\(jobId, privacy: .public), attempt=\(self.jobs[idx].attempts, privacy: .public), error=\(message, privacy: .public)")
+
+        if isPermanentError(error) || jobs[idx].attempts >= options.maxRetries {
+            jobs[idx].status = .failed
+            jobs[idx].errorMessage = message
+            jobs[idx].finishedAt = Date()
+        } else {
+            // 可重试：回退到 queued，主循环下一轮会重新拉取（重试次数已在 processNext 入口 +1）。
+            jobs[idx].status = .queued
+        }
+    }
+
+    /// 不可重试错误判别：用户没改配置之前永远会失败的那一类。
+    private func isPermanentError(_ error: Error) -> Bool {
+        if let insight = error as? RepoAIInsightError {
+            switch insight {
+            case .missingAPIKey, .missingProvider:
+                return true
+            case .invalidJSON:
+                return false
+            }
+        }
+        return false
+    }
+
+    // MARK: - Repo 缓存（避免每次 processSingle 都查库）
+
+    /// repoId → Repo 的会话内缓存。由 start() 时填充。
+    private var repoCache: [Int64: Repo] = [:]
+}

--- a/Starcat/Features/AI/BatchAIQueueService.swift
+++ b/Starcat/Features/AI/BatchAIQueueService.swift
@@ -149,13 +149,33 @@ final class BatchAIQueueService {
         Task { await runLoop() }
     }
 
-    /// 取消整批：标记 cancel → 不杀当前 in-flight job → 标记 isRunning = false。
+    /// 取消整批。
+    ///
+    /// 用户反馈（HOM-52 2026-06-06 17:26 dong4j）：原版本只设标志位，
+    /// AI 调用可能要 5-10 秒，用户看不到任何视觉反馈以为"按钮没效果"。
+    ///
+    /// 改进后的行为：
+    /// 1. **立即清空所有 queued jobs** —— 列表长度立刻下降，给用户可见反馈。
+    /// 2. **设置 cancelRequested 标志**，runLoop 在当前 await 完成后立刻 break。
+    /// 3. **派生 isCancelling 状态**供 UI 显示"正在终止..."提示，按钮 disable。
+    /// 4. **当前 in-flight 的 AI 调用不强制中断**：OpenAIClient 没有 cancel 通道，
+    ///    且强中断后的 partial response 处理代价大；当前 job 跑完即丢弃结果。
+    /// 5. **runLoop 退出时**把残留 processing 状态的 job 标记为 failed("用户取消")，
+    ///    避免 UI 上留下"永远在 processing"的孤儿行。
     func cancel() {
         guard isRunning else { return }
         cancelRequested = true
         isPaused = false
-        AppLog.ai.notice("[batch-ai] cancel requested")
+        // 立即清空所有未开始的 job，给用户立即可见的反馈。
+        // 已完成 / 已忽略 / 已失败 / processing 的 job 保留，不破坏历史记录。
+        let removed = jobs.filter { $0.status == .queued }.count
+        jobs.removeAll { $0.status == .queued }
+        AppLog.ai.notice("[batch-ai] cancel requested, cleared \(removed, privacy: .public) queued jobs")
     }
+
+    /// UI 派生：true 时显示"正在终止当前 AI 调用..."提示。
+    /// 触发后 runLoop 仍在等 in-flight job 跑完（最多几十秒），需要给用户解释。
+    var isCancelling: Bool { cancelRequested && isRunning }
 
     /// 重置：清空全部 jobs / options / 进度。
     /// 调用方场景：用户点 panel 的"关闭"按钮且已 finished，或新开一批整理前。
@@ -232,8 +252,11 @@ final class BatchAIQueueService {
 
             do {
                 let result = try await processSingle(jobId: jobSnapshot.repoId, options: options)
+                // 用户在 AI 调用期间点了取消 → 丢弃结果，循环顶部下一轮会 break。
+                if cancelRequested { break }
                 await applyResult(jobId: jobSnapshot.repoId, result: result, options: options)
             } catch {
+                if cancelRequested { break }
                 handleFailure(jobId: jobSnapshot.repoId, error: error, options: options)
             }
 
@@ -245,6 +268,16 @@ final class BatchAIQueueService {
 
         // 循环退出：若全部终态则关掉 isRunning；否则保留状态等用户 resume / cancel。
         if isFinished || cancelRequested || jobs.allSatisfy({ $0.status != .queued }) {
+            // 用户取消时，把可能停在 .processing 的孤儿 job 收尾，避免 UI 留"永远转圈"行。
+            if cancelRequested {
+                let now = Date()
+                let reason = String(localized: "batchAI.panel.cancelledByUser")
+                for idx in jobs.indices where jobs[idx].status == .processing {
+                    jobs[idx].status = .failed
+                    jobs[idx].errorMessage = reason
+                    jobs[idx].finishedAt = now
+                }
+            }
             isRunning = false
             currentJobId = nil
             if isFinished {

--- a/Starcat/Features/AI/BatchAIQueueService.swift
+++ b/Starcat/Features/AI/BatchAIQueueService.swift
@@ -398,11 +398,12 @@ final class BatchAIQueueService {
             return existing
         }
         let now = ISO8601DateFormatter.shared.string(from: Date())
+        let visual = Self.visualForNewTag(name: name)
         let tag = Tag(
             id: UUID().uuidString,
             name: name,
-            color: nil,
-            icon: "tag",
+            color: visual.colorHex,
+            icon: visual.iconName,
             sortOrder: 0,
             isPreset: false,
             parentId: nil,
@@ -411,6 +412,26 @@ final class BatchAIQueueService {
         )
         try await tagRepository.create(tag)
         return tag
+    }
+
+    /// 为新建的标签挑一个颜色 + 图标。
+    ///
+    /// 用户反馈（HOM-52 2026-06-06 17:43 dong4j）：批量创建的标签全是蓝色，
+    /// 同名标签每次创建应保持视觉一致——所以用**稳定哈希**而非 randomElement()。
+    ///
+    /// 算法：FNV-1a 32-bit。`hashValue` 不能用，Swift 文档明确每次进程启动 seed 会变，
+    /// 这会导致今天新建「Swift」是红色、明天重启再新建「SwiftUI」时哈希分布完全不同。
+    /// FNV-1a 实现简单且跨进程稳定，对 12 色 / 30 图标这种小桶足够均匀。
+    private static func visualForNewTag(name: String) -> (colorHex: String, iconName: String) {
+        var hash: UInt32 = 2_166_136_261
+        for byte in name.utf8 {
+            hash ^= UInt32(byte)
+            hash = hash &* 16_777_619
+        }
+        // 颜色和图标用不同的位段，避免两者同步变化导致组合多样性下降。
+        let colorIdx = Int(hash % UInt32(TagColorPalette.presets.count))
+        let iconIdx = Int((hash >> 8) % UInt32(SFSymbolPreset.icons.count))
+        return (TagColorPalette.presets[colorIdx].hex, SFSymbolPreset.icons[iconIdx])
     }
 
     /// 处理单个 job 的失败：分流"重试" vs "终态失败"。

--- a/Starcat/Features/AI/BatchAIUntaggedBanner.swift
+++ b/Starcat/Features/AI/BatchAIUntaggedBanner.swift
@@ -1,0 +1,94 @@
+//
+//  BatchAIUntaggedBanner.swift
+//  Starcat
+//
+//  HOM-52 - Untagged 视图顶部"开始批量 AI 整理"入口横幅。
+//
+//  模块职责：
+//  - 在 RepoListView 的 Untagged 视图顶部展示一个轻量横幅。
+//  - 显示当前未分类仓库数 + 启动按钮 / 查看进度按钮。
+//  - 与队列服务状态联动：进行中 / 已完成时按钮文案与图标变化。
+//
+//  关键约束：
+//  - 仅在 selection == .untagged 时显示，避免污染其它视图。
+//  - 队列已在跑时按钮变为"查看进度"，点击直接打开 panel（不要求重新选择 options）。
+//
+
+import SwiftUI
+
+struct BatchAIUntaggedBanner: View {
+
+    let untaggedCount: Int
+    @Bindable var service: BatchAIQueueService
+
+    let onStart: () -> Void
+    let onShowPanel: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 16))
+                .foregroundStyle(.tint)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(format: String(localized: "batchAI.banner.titleFormat"), untaggedCount))
+                    .font(.subheadline.weight(.medium))
+                Text(secondaryText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+
+            actionButton
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(.tint.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(.tint.opacity(0.18))
+        )
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var actionButton: some View {
+        if service.isRunning || (!service.jobs.isEmpty && !service.isFinished) {
+            Button {
+                onShowPanel()
+            } label: {
+                Label("batchAI.banner.viewProgress", systemImage: "rectangle.stack")
+            }
+            .controlSize(.regular)
+        } else {
+            Button {
+                onStart()
+            } label: {
+                Label("batchAI.banner.start", systemImage: "play.fill")
+            }
+            .controlSize(.regular)
+            .buttonStyle(.borderedProminent)
+            .disabled(untaggedCount == 0)
+        }
+    }
+
+    /// 副标题：未运行时给提示，运行 / 完成时显示当前状态摘要。
+    private var secondaryText: String {
+        if service.isRunning {
+            if service.isPaused {
+                return String(format: String(localized: "batchAI.banner.runningPausedFormat"), service.finishedCount, service.totalCount)
+            }
+            return String(format: String(localized: "batchAI.banner.runningFormat"), service.finishedCount, service.totalCount)
+        }
+        if service.isFinished {
+            return String(format: String(localized: "batchAI.banner.finishedFormat"), service.completedCount, service.failedCount)
+        }
+        return String(localized: "batchAI.banner.hint")
+    }
+}

--- a/Starcat/Features/AI/RepoAIInsightService.swift
+++ b/Starcat/Features/AI/RepoAIInsightService.swift
@@ -97,21 +97,39 @@ final class RepoAIInsightService {
         let source = try await makeSource(for: repo)
         let generatedAt = ISO8601DateFormatter.shared.string(from: Date())
 
-        // HOM-52：批量整理路径会在 source 文本末尾追加"现有标签提示"。
-        // 详情页单仓路径默认传 [] / true / true，行为完全不变。
+        // HOM-52：标签生成路径在 source 末尾追加两段强制约束：
+        //   (1) Tag format rules —— 限制中英文标签长度 / 风格，覆盖所有用户 prompt（含自定义）
+        //   (2) Existing user tags —— 批量路径传入时引导 AI 优先复用
+        //
+        // 为何不写进 default prompt：用户可能已经在 Settings 改过 prompt（持久化在 UserDefaults），
+        // 改 default 对老用户不生效。注入到 {context} 末尾走的是同一个 prompt template 替换路径，
+        // 无论用户怎么改 system / user prompt 都会拿到这两段规则。
+        // includeTags == false 时不注入，避免摘要任务的 prompt 被无关规则污染。
         let augmentedSource: Source = {
-            guard !existingTagHints.isEmpty, includeTags else { return source }
+            guard includeTags else { return source }
+
+            var appendix = """
+
+            Tag format rules (必须遵守):
+            - 中文标签：长度 ≤ 4 字（如「向量检索」「编辑器」「机器学习」），名词或简短术语，不要句子。
+            - 英文标签：单个领域词、专业缩写或常见技术术语（如 RAG / LLM / Vector / DevOps / WebRTC / Editor），不要复合短语。
+            - 中英文混用时每个标签独立判断；同一仓库的标签风格保持一致。
+            """
+
             let trimmedHints = existingTagHints
                 .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
                 .filter { !$0.isEmpty }
                 .prefix(50)
-            guard !trimmedHints.isEmpty else { return source }
-            let hintBlock = """
+            if !trimmedHints.isEmpty {
+                appendix += """
 
-            Existing user tags (优先复用，无法归类的才新增；避免标签数量爆炸):
-            \(trimmedHints.joined(separator: ", "))
-            """
-            let merged = source.text + hintBlock
+
+                Existing user tags (优先复用，无法归类的才新增；避免标签数量爆炸):
+                \(trimmedHints.joined(separator: ", "))
+                """
+            }
+
+            let merged = source.text + appendix
             return Source(text: merged, hash: Self.hash(merged))
         }()
 

--- a/Starcat/Features/AI/RepoAIInsightService.swift
+++ b/Starcat/Features/AI/RepoAIInsightService.swift
@@ -89,14 +89,50 @@ final class RepoAIInsightService {
 
     func generateInsight(
         for repo: Repo,
+        existingTagHints: [String] = [],
+        includeSummary: Bool = true,
+        includeTags: Bool = true,
         onSummaryDelta: (@MainActor (String) -> Void)? = nil
     ) async throws -> RepoAIInsightGeneration {
         let source = try await makeSource(for: repo)
         let generatedAt = ISO8601DateFormatter.shared.string(from: Date())
 
-        async let tagResult = tagSuggestionsResult(source: source)
-        let summaryText = try await generateSummary(source: source, onDelta: onSummaryDelta)
-        let resolvedTagResult = await tagResult
+        // HOM-52：批量整理路径会在 source 文本末尾追加"现有标签提示"。
+        // 详情页单仓路径默认传 [] / true / true，行为完全不变。
+        let augmentedSource: Source = {
+            guard !existingTagHints.isEmpty, includeTags else { return source }
+            let trimmedHints = existingTagHints
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .prefix(50)
+            guard !trimmedHints.isEmpty else { return source }
+            let hintBlock = """
+
+            Existing user tags (优先复用，无法归类的才新增；避免标签数量爆炸):
+            \(trimmedHints.joined(separator: ", "))
+            """
+            let merged = source.text + hintBlock
+            return Source(text: merged, hash: Self.hash(merged))
+        }()
+
+        // 两者都需要时并发跑（与原实现一致）；任一关闭则串行 / 短路，避免无意义 AI 调用。
+        let summaryText: String
+        let resolvedTagResult: Result<[AITagSuggestion], Error>
+        if includeSummary, includeTags {
+            async let tagResult = tagSuggestionsResult(source: augmentedSource)
+            summaryText = try await generateSummary(source: augmentedSource, onDelta: onSummaryDelta)
+            resolvedTagResult = await tagResult
+        } else if includeSummary {
+            summaryText = try await generateSummary(source: augmentedSource, onDelta: onSummaryDelta)
+            resolvedTagResult = .success([])
+        } else if includeTags {
+            summaryText = ""
+            resolvedTagResult = await tagSuggestionsResult(source: augmentedSource)
+        } else {
+            // 调用方两者都关：返回空 insight，避免无意义网络调用。
+            summaryText = ""
+            resolvedTagResult = .success([])
+        }
         let suggestions = (try? resolvedTagResult.get()) ?? []
         let tagErrorMessage: String? = {
             if case .failure(let error) = resolvedTagResult {
@@ -116,15 +152,19 @@ final class RepoAIInsightService {
         // 保留旧字段的同时把新摘要正文写进 summaryMarkdown，UI 优先读该字段。
         insight.summaryMarkdown = summaryText
 
-        let jsonData = try JSONEncoder().encode(insight)
-        let record = AISummaryRecord(
-            repoId: repo.id,
-            model: cacheModelKey(),
-            sourceHash: source.hash,
-            summaryJson: String(decoding: jsonData, as: UTF8.self),
-            generatedAt: generatedAt
-        )
-        try await summaryRepository.upsert(record)
+        // HOM-52：只跑标签（includeSummary == false）时不写 ai_summaries 缓存——
+        // 否则会用空 summaryText 覆盖已有的有效摘要缓存。调用方仍能拿到 suggestions。
+        if includeSummary {
+            let jsonData = try JSONEncoder().encode(insight)
+            let record = AISummaryRecord(
+                repoId: repo.id,
+                model: cacheModelKey(),
+                sourceHash: source.hash,
+                summaryJson: String(decoding: jsonData, as: UTF8.self),
+                generatedAt: generatedAt
+            )
+            try await summaryRepository.upsert(record)
+        }
         return RepoAIInsightGeneration(insight: insight, tagErrorMessage: tagErrorMessage)
     }
 

--- a/Starcat/Features/Home/HomeView.swift
+++ b/Starcat/Features/Home/HomeView.swift
@@ -65,6 +65,13 @@ struct HomeView: View {
     /// W4 A2：标签管理 sheet 显示状态。
     @State private var showTagManagement: Bool = false
 
+    /// HOM-52：批量 AI 整理"操作选择" sheet 显示状态。
+    @State private var showBatchAIOptions: Bool = false
+    /// HOM-52：批量 AI 整理进度面板 sheet 显示状态。
+    @State private var showBatchAIPanel: Bool = false
+    /// HOM-52：当前正在编辑的 Options（启动 sheet 时初始化，跨 sheet 关闭保留以记住上次选择）。
+    @State private var batchAIOptions: BatchAIQueueOptions = BatchAIQueueOptions()
+
     /// 三栏显示状态。
     ///
     /// 为什么显式持有：
@@ -170,7 +177,15 @@ struct HomeView: View {
                 selectedTrendingRepoID: $selectedTrendingRepoID,
                 selectedTrendingRepo: $selectedTrendingRepo,
                 selectedActivityCategory: $selectedActivityCategory,
-                selectedActivityItem: $selectedActivityItem
+                selectedActivityItem: $selectedActivityItem,
+                onStartBatchAI: {
+                    // HOM-52：点击 banner"开始整理" → 弹 Options sheet。
+                    // 复用上一次 batchAIOptions，让"再开一次"沿用最近偏好。
+                    showBatchAIOptions = true
+                },
+                onShowBatchAIPanel: {
+                    showBatchAIPanel = true
+                }
             )
                 .navigationSplitViewColumnWidth(min: 420, ideal: 420, max: 520)
         } detail: {
@@ -208,6 +223,29 @@ struct HomeView: View {
             ReleaseTimelineView()
                 .environment(dependencies)
         }
+        // HOM-52：批量 AI 整理"操作选择" sheet
+        .sheet(isPresented: $showBatchAIOptions) {
+            BatchAIOptionsSheet(
+                pendingCount: viewModel.untaggedCount,
+                options: $batchAIOptions,
+                onCancel: {
+                    showBatchAIOptions = false
+                },
+                onStart: {
+                    showBatchAIOptions = false
+                    Task {
+                        await startBatchAIIntegration()
+                    }
+                }
+            )
+        }
+        // HOM-52：批量 AI 整理进度面板
+        .sheet(isPresented: $showBatchAIPanel) {
+            BatchAIQueuePanel(
+                service: dependencies.batchAIQueueService,
+                onClose: { showBatchAIPanel = false }
+            )
+        }
         // HOM-47：登录后启动后台 Release 轮询；登出时停。
         // 与 SyncManager 不同：Release Poller 自调度（NSBackgroundActivityScheduler），
         // 启动一次后由系统在后台触发；这里只负责启停门控。
@@ -222,6 +260,15 @@ struct HomeView: View {
             // 启动 / 重新进入 HomeView 时默认回三栏展开。运行期用户手动缩窗时，
             // 系统仍可按窗口宽度自动折叠 sidebar；这里只负责启动态保真。
             columnVisibility = .all
+
+            // HOM-52：批量整理服务挂接 Sidebar 刷新回调。
+            // 每应用一批标签就 refreshSidebar，让 Sidebar Tags 段计数实时跟随；
+            // 不在 viewModel.reloadItems()——避免大批次每个 repo 都全量重拉列表。
+            dependencies.batchAIQueueService.onTagsChanged = {
+                Task { @MainActor in
+                    await viewModel.refreshSidebar()
+                }
+            }
 
             // W4-4 D1/D2:把持久化的视图偏好同步到 viewModel,避免首次 reloadItems 用默认值
             // 然后 onAppear 才纠正导致列表抖动一次。
@@ -469,6 +516,29 @@ struct HomeView: View {
         case .loaded(let html, _):
             return "loaded:\(html.count)"
         }
+    }
+
+    /// HOM-52：用户点击 banner"开始整理"后的真正启动入口。
+    ///
+    /// 流程：
+    /// 1. 从 RepoRepository 拉取 fetchUntagged() 作为本次整理输入集（不依赖 viewModel.items，
+    ///    避免搜索过滤后的子集被误处理）。
+    /// 2. 调 BatchAIQueueService.start 启动队列。
+    /// 3. 立刻打开进度面板让用户看到第一帧。
+    ///
+    /// 错误处理：fetchUntagged 失败仅记日志，不弹错——这是用户主动触发的场景，
+    /// 失败时按钮仍可继续点（dependencies 状态未变，第二次点击会重试）。
+    private func startBatchAIIntegration() async {
+        let untagged: [Repo]
+        do {
+            untagged = try await dependencies.repoRepository.fetchUntagged()
+        } catch {
+            AppLog.ai.error("[batch-ai] fetchUntagged failed: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        guard !untagged.isEmpty else { return }
+        dependencies.batchAIQueueService.start(repos: untagged, options: batchAIOptions)
+        showBatchAIPanel = true
     }
 
     /// 校验一个 Manage 分类当前是否仍然有效（用于跨启动恢复时兜底）。

--- a/Starcat/Features/Home/RepoListView.swift
+++ b/Starcat/Features/Home/RepoListView.swift
@@ -22,6 +22,8 @@ struct RepoListView: View {
 
     @Environment(HomeViewModel.self) private var viewModel
     @Environment(AppSettings.self) private var settings
+    /// HOM-52：批量 AI 整理入口横幅需要查询队列状态。
+    @Environment(AppDependencies.self) private var dependencies
 
     /// HOM-54：TrendingRepository，用于渲染 Trending 页面。
     var trendingRepository: (any TrendingRepositoryProtocol)?
@@ -38,6 +40,11 @@ struct RepoListView: View {
     @Binding var selectedActivityCategory: ActivityCategory
     /// Activity 页当前选中项，驱动右侧详情。
     @Binding var selectedActivityItem: ActivityItem?
+
+    /// HOM-52：Untagged 视图顶部 banner 的"启动整理 / 查看进度"回调。
+    /// 这两个动作产生 sheet 由 HomeView 统一承载（避免 RepoListView 多持一个 @State）。
+    var onStartBatchAI: (() -> Void)?
+    var onShowBatchAIPanel: (() -> Void)?
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -138,10 +145,34 @@ struct RepoListView: View {
                 emptyState(systemImage: emptyImage, title: emptyTitle, subtitle: emptySubtitle)
             } else if viewModel.isMultiSelectMode {
                 // W4 A5：多选模式 List binding 类型不同，必须分开渲染
-                multiSelectList($vm.multiSelectedRepoIDs)
+                listWithOptionalBanner { multiSelectList($vm.multiSelectedRepoIDs) }
             } else {
-                listContent($vm.selectedRepoID)
+                listWithOptionalBanner { listContent($vm.selectedRepoID) }
             }
+        }
+    }
+
+    /// HOM-52：仅在 Untagged 视图非空时，在列表顶部插入"批量 AI 整理"入口横幅。
+    ///
+    /// 之所以包成 ViewBuilder + closure 而不是把 banner 塞进每个 list view：
+    /// listContent / multiSelectList 都是带泛型 selection 的 List，加 banner 会破坏 List 滚动语义；
+    /// 在外层 VStack 拼接更稳，且 banner 也参与 contentAnimationID 触发的过渡动画。
+    @ViewBuilder
+    private func listWithOptionalBanner<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        if selectedPage == .manage, viewModel.selection == .untagged {
+            VStack(spacing: 0) {
+                BatchAIUntaggedBanner(
+                    // 用 untaggedCount 而非 items.count：搜索过滤后 items 会少，
+                    // 但 banner 反映的是"全部未分类仓库"总量，与"开始整理"动作语义一致。
+                    untaggedCount: viewModel.untaggedCount,
+                    service: dependencies.batchAIQueueService,
+                    onStart: { onStartBatchAI?() },
+                    onShowPanel: { onShowBatchAIPanel?() }
+                )
+                content()
+            }
+        } else {
+            content()
         }
     }
 

--- a/Starcat/Resources/Localizable.xcstrings
+++ b/Starcat/Resources/Localizable.xcstrings
@@ -3287,6 +3287,678 @@
         }
       }
     },
+    "batchAI.banner.finishedFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finished. Completed %1$d, Failed %2$d"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已完成。成功 %1$d，失败 %2$d"
+          }
+        }
+      }
+    },
+    "batchAI.banner.hint" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Let AI generate summaries and recommend tags in one batch."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "让 AI 一次性为所有未分类仓库生成摘要并推荐标签。"
+          }
+        }
+      }
+    },
+    "batchAI.banner.runningFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Running %1$d / %2$d"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整理中 %1$d / %2$d"
+          }
+        }
+      }
+    },
+    "batchAI.banner.runningPausedFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paused at %1$d / %2$d"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已暂停 %1$d / %2$d"
+          }
+        }
+      }
+    },
+    "batchAI.banner.start" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开始整理"
+          }
+        }
+      }
+    },
+    "batchAI.banner.titleFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d untagged repositories"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 个未分类仓库"
+          }
+        }
+      }
+    },
+    "batchAI.banner.viewProgress" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View Progress"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看进度"
+          }
+        }
+      }
+    },
+    "batchAI.options.action.summary" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generate AI Summary"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生成 AI 摘要"
+          }
+        }
+      }
+    },
+    "batchAI.options.action.summary.desc" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Structured Chinese summary, cached locally."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "结构化中文摘要，本地缓存。"
+          }
+        }
+      }
+    },
+    "batchAI.options.action.tags" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recommend Tags"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推荐标签"
+          }
+        }
+      }
+    },
+    "batchAI.options.action.tags.desc" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI suggests 3-8 tags per repo with confidence."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "为每个仓库推荐 3-8 个含置信度的标签。"
+          }
+        }
+      }
+    },
+    "batchAI.options.actionsLabel" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose actions to run (at least one)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择要执行的操作（至少一项）"
+          }
+        }
+      }
+    },
+    "batchAI.options.autoApply" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-apply recommended tags"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动应用推荐标签"
+          }
+        }
+      }
+    },
+    "batchAI.options.autoApply.desc" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apply high-confidence tags without per-repo confirmation."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无需逐个确认，自动写入高于阈值的标签。"
+          }
+        }
+      }
+    },
+    "batchAI.options.estimateFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estimated time: about %d minutes"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预计耗时：约 %d 分钟"
+          }
+        }
+      }
+    },
+    "batchAI.options.startFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start (%d)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开始整理 (%d)"
+          }
+        }
+      }
+    },
+    "batchAI.options.subtitleFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Process %d untagged repositories"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本次将处理 %d 个未分类仓库"
+          }
+        }
+      }
+    },
+    "batchAI.options.threshold" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confidence threshold"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "置信度阈值"
+          }
+        }
+      }
+    },
+    "batchAI.options.threshold.hintFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tags below %@ will be ignored"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低于 %@ 的标签将被自动忽略"
+          }
+        }
+      }
+    },
+    "batchAI.options.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batch AI Tidy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "批量 AI 整理"
+          }
+        }
+      }
+    },
+    "batchAI.panel.cancel" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
+    },
+    "batchAI.panel.counter.completed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completed"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "成功"
+          }
+        }
+      }
+    },
+    "batchAI.panel.counter.failed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "失败"
+          }
+        }
+      }
+    },
+    "batchAI.panel.counter.ignored" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignored"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "忽略"
+          }
+        }
+      }
+    },
+    "batchAI.panel.currentFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Now: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前：%@"
+          }
+        }
+      }
+    },
+    "batchAI.panel.failedSummaryFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d failed"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d 个失败"
+          }
+        }
+      }
+    },
+    "batchAI.panel.finished" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All done"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部完成"
+          }
+        }
+      }
+    },
+    "batchAI.panel.pause" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pause"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂停"
+          }
+        }
+      }
+    },
+    "batchAI.panel.paused" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paused"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已暂停"
+          }
+        }
+      }
+    },
+    "batchAI.panel.progressFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progress %1$d / %2$d"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "进度 %1$d / %2$d"
+          }
+        }
+      }
+    },
+    "batchAI.panel.remainingMinutesFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "about %d min left"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "约 %d 分钟"
+          }
+        }
+      }
+    },
+    "batchAI.panel.remainingSecondsFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "about %d sec left"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "约 %d 秒"
+          }
+        }
+      }
+    },
+    "batchAI.panel.resume" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resume"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继续"
+          }
+        }
+      }
+    },
+    "batchAI.panel.retry" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重试"
+          }
+        }
+      }
+    },
+    "batchAI.panel.retryAll" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry All"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重试全部"
+          }
+        }
+      }
+    },
+    "batchAI.panel.row.appliedTagsFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Applied: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已应用：%@"
+          }
+        }
+      }
+    },
+    "batchAI.panel.row.completedNoTags" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suggested tags saved; waiting for confirmation"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保存推荐标签，等待你在详情页确认"
+          }
+        }
+      }
+    },
+    "batchAI.panel.row.failedUnknown" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unknown error"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知错误"
+          }
+        }
+      }
+    },
+    "batchAI.panel.row.ignoredFormat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignored (below threshold): %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已忽略（低于阈值）：%@"
+          }
+        }
+      }
+    },
+    "batchAI.panel.row.processing" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Processing..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "处理中..."
+          }
+        }
+      }
+    },
+    "batchAI.panel.row.summaryOnly" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Summary generated"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摘要已生成"
+          }
+        }
+      }
+    },
+    "batchAI.panel.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batch AI Tidy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "批量 AI 整理"
+          }
+        }
+      }
+    },
     "batch.noMatch" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Starcat/Resources/Localizable.xcstrings
+++ b/Starcat/Resources/Localizable.xcstrings
@@ -3618,7 +3618,55 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "取消"
+            "value" : "终止"
+          }
+        }
+      }
+    },
+    "batchAI.panel.cancelledByUser" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelled by user"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用户已取消"
+          }
+        }
+      }
+    },
+    "batchAI.panel.cancelling" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelling"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在终止"
+          }
+        }
+      }
+    },
+    "batchAI.panel.cancellingDetail" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for the current AI call to finish before stopping..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在等待当前 AI 调用结束后停止..."
           }
         }
       }


### PR DESCRIPTION
关联任务：[HOM-52](https://multica.ai/issue/95fef566-ce75-4e28-a6ce-9cc2e4cbe0b7) — `[Feature]:[AI整理] 批量未分类仓库 AI 整理`

> 草稿 PR：HOM-52 验收范围内已实现完毕，开成 draft 供 review；HOM-126 的合规化补齐（持久化 / 多选 / 成本估算 / 强制确认）在另一组 PR 跟进。

## 范围

按 `docs/功能清单.md §2.7` + Issue 评审决议落地"未分类仓库批量 AI 整理"：

- 选择要执行的子任务（摘要 / 推荐标签）。
- 内存队列：暂停 / 继续 / 失败重试 / 单项状态可视。
- 自动应用阈值（默认关 / 置信度 0.9），低于阈值的 tag 落 `ignored`。
- 现有标签作为 prompt context 注入，新 tag 沿用稳定哈希分配颜色 + SF Symbol。
- AI 标签格式约束（中文 ≤ 4 字 / 英文专业术语）通过 prompt context 注入。

## 主要改动

- `Features/AI/BatchAIQueueModels.swift` — `BatchAIJob` / `BatchAIJobStatus` / `BatchAIAction` / `BatchAIQueueOptions`
- `Features/AI/BatchAIQueueService.swift` — `@Observable` 单例队列服务，含 runLoop / cancel / retry / 稳定哈希 tag 配色
- `Features/AI/BatchAIOptionsSheet.swift` — 启动前选项 Sheet（OptionCard 风格，弃用 system toggle.switch）
- `Features/AI/BatchAIQueuePanel.swift` — 浮动进度面板（暂停 / 继续 / 终止 / 单项状态）
- `Features/AI/BatchAIUntaggedBanner.swift` — Untagged 视图顶部入口 banner
- `Features/AI/RepoAIInsightService.swift` — 扩参（`existingTagHints` / `includeSummary` / `includeTags`），注入 tag 格式约束
- `App/AppDependencies.swift`、`Features/Home/{HomeView,RepoListView}.swift` — 服务注册 + UI 接线
- `Resources/Localizable.xcstrings` — 新增 38+ batchAI.\* 键（zh-Hans / en）

## Commit 历史

```
66a73a2 style(starcat): HOM-52 阈值滑条卡片左侧与 OptionCard 对齐
e82f3ab refactor(starcat): HOM-52 重做批量整理选项 sheet UI
3eed1e6 fix(starcat): HOM-52 标签创建随机配色 + AI 标签格式强约束
9d3aa53 fix(starcat): HOM-52 终止按钮立即反馈（清队列 + 显示"正在终止"）
59e6323 feat(starcat): HOM-52 批量未分类仓库 AI 整理（队列 + 浮动面板）
```

## 验收对照（HOM-52）

- [x] Banner 入口显示未分类仓库数 + 启动按钮
- [x] 选项 Sheet：操作选择 / 自动应用 / 置信度阈值 / 启动按钮
- [x] 浮动进度面板：实时计数 / 当前任务 / 单项状态列表
- [x] 暂停 / 继续 / 终止
- [x] 失败重试（指数退避 + 永久失败识别）
- [x] 后台继续（panel 关闭后服务在内存里继续跑）
- [x] 应用后 sidebar 自动刷新

## 已知遗留（移交 HOM-126）

| 项 | 当前实现 | HOM-126 要求 |
|---|---|---|
| 队列存储 | 内存 | SQLite 持久化 + 启动恢复 |
| 范围选择 | 自动扫全部未分类 | 用户多选明确选择 |
| 落库方式 | auto-apply + 摘要直接写 | 默认走"建议态评审"，auto-apply 退化为高级选项 |
| 成本提示 | 仅时长 | token / 调用次数 / 费用估算 |

HOM-126 实现方案已在父任务评论里同步给 dong4j，待两处决策（auto-apply 是否保留、"分类"如何定义）拍板后开始。

## 测试

- macOS 本地手测：1809 个未分类仓库的真实样本。
  - 启动 / 暂停 / 继续 / 终止 行为符合预期。
  - 终止按钮加 isCancelling 后立即清空 queued、显示"正在终止"。
  - 新 tag 配色多样且同名稳定。
  - AI 返回的中文 tag 实测多为 2-4 字、英文多为缩写或单词。
- `xcodebuild -scheme Starcat -configuration Debug` 通过。
- 暂无单元测试覆盖（项目当前批量整理流程没有现成 fixture，留作 HOM-126 持久化做完后补 repo 层测试）。

## Reviewer 关注点

1. `BatchAIQueueService.runLoop` 的 cancel 路径——是否需要更强的中断（当前依赖 await 边界）。
2. `findOrCreateTag` 的 FNV-1a 稳定哈希——可否接受作为新 tag 默认配色策略，还是希望走「让用户在 Tag Management 改色」纯人工路线。
3. `RepoAIInsightService` 注入 tag 格式约束的位置——是否会破坏老用户自定义 prompt 的语义。

Made with [Cursor](https://cursor.com)