### PR TITLE
[HOM-179] feat(sidebar): 标签墙改造 + 多选 OR / 与 Languages AND 过滤 + UI 强化

### DIFF
--- a/Starcat/Core/Sync/RepoTagRepository.swift
+++ b/Starcat/Core/Sync/RepoTagRepository.swift
@@ -123,6 +123,28 @@ struct GRDBRepoTagRepository: RepoTagRepositoryProtocol {
         }
     }
 
+    /// 多标签 AND 查询：返回同时拥有所有指定标签的 repo。
+    func fetchRepos(forTags tagIds: Set<String>) async throws -> [Repo] {
+        guard !tagIds.isEmpty else { return [] }
+        return try await writer.read { db in
+            // 使用 HAVING COUNT 确保 repo 同时拥有所有指定标签
+            let tagArray = Array(tagIds)
+            let placeholders = tagArray.map { _ in "?" }.joined(separator: ", ")
+            let sql = """
+                SELECT r.* FROM repos r
+                JOIN repo_tags rt ON rt.repo_id = r.id
+                WHERE rt.tag_id IN (\(placeholders)) AND r.is_starred = 1
+                GROUP BY r.id
+                HAVING COUNT(DISTINCT rt.tag_id) = ?
+                ORDER BY r.starred_at DESC
+                """
+            // 构建参数：前 N 个是 tagId，最后一个是 tagIds.count
+            var arguments: [DatabaseValueConvertible] = tagArray
+            arguments.append(tagArray.count)
+            return try Repo.fetchAll(db, sql: sql, arguments: StatementArguments(arguments))
+        }
+    }
+
     func repoCount(forTag tagId: String) async throws -> Int {
         try await writer.read { db in
             try Int.fetchOne(db, sql: """

--- a/Starcat/Core/Sync/RepoTagRepositoryProtocol.swift
+++ b/Starcat/Core/Sync/RepoTagRepositoryProtocol.swift
@@ -47,6 +47,10 @@ protocol RepoTagRepositoryProtocol: Sendable {
     /// 某标签下的所有 repo（join repos，按 starred_at desc，仅 is_starred=1）。
     func fetchRepos(forTag tagId: String) async throws -> [Repo]
 
+    /// 多标签 AND 查询：返回同时拥有所有指定标签的 repo。
+    /// 用于标签墙多选场景。
+    func fetchRepos(forTags tagIds: Set<String>) async throws -> [Repo]
+
     /// 某标签下的 repo 数量（用于 Sidebar Tags 行显示计数）。
     func repoCount(forTag tagId: String) async throws -> Int
 

--- a/Starcat/Features/Home/HomeViewModel.swift
+++ b/Starcat/Features/Home/HomeViewModel.swift
@@ -225,6 +225,36 @@ final class HomeViewModel {
     /// W4 A6：tagId → starred repo count（Sidebar Tags 行右侧计数）。
     private(set) var tagCounts: [String: Int] = [:]
 
+    // MARK: - HOM-179：标签墙多选过滤
+
+    /// HOM-179：标签墙多选过滤（OR 逻辑）。
+    ///
+    /// 与 `selection` 的关系（用户口径，2026-06-07）：
+    /// - **selectedTagIds 内部多个标签**：OR —— 命中任意一个即保留
+    ///   （示例：选 tag1 + tag2 → 显示 tag1 或 tag2 的 repo）
+    /// - **selectedTagIds 与 selection（Languages / All Stars / Untagged）**：AND
+    ///   （示例：Java + tag1 + tag2 → 必须是 Java 且至少有 tag1 或 tag2）
+    ///
+    /// 实现方式：
+    /// - 不入 `selection`，独立成 filter；selection 仍然只决定 base set
+    /// - `applyView()` 在 base set 上做 OR 过滤（用 `repoTagsMap` 查 repo→tagIds）
+    /// - 这样切 Languages 也保持已选 tags（AND 组合自然成立）
+    /// - didSet 触发 `applyView()` 而非 `reloadItems()`，因为 base set 没变，只是过滤结果变了
+    var selectedTagIds: Set<String> = [] {
+        didSet {
+            guard oldValue != selectedTagIds else { return }
+            applyView()
+        }
+    }
+
+    /// HOM-179：repo → 它拥有的 tagIds。
+    /// `applyView()` 用这张表做 OR 过滤；`refreshSidebar()` 一次拉全量并刷新。
+    /// 之所以走"全量内存映射 + 客户端过滤"而非"为每次切换查 IN/OR SQL"：
+    /// - 总量 1801 repos × 平均 ~3 tags = 几千条映射，内存占用可忽略（<100KB）
+    /// - 切 Languages / 勾 / 取消标签时不发起 DB 查询，UI 即时响应
+    /// - 与现有 `statusMap` 走的"全表加载到字典 + applyView 过滤"路径完全一致
+    private var repoTagsMap: [Int64: Set<String>] = [:]
+
     // MARK: - 多选模式（W4 A5）
 
     /// 是否进入多选模式。开启后中栏 List 切换到多选 selection binding。
@@ -363,15 +393,71 @@ final class HomeViewModel {
             async let langs = repository.languageStats()
             async let tagsResult = tagRepository.fetchAll()
             async let tagCountsResult = repoTagRepository.repoCountsByTag()
+            // HOM-179：一并刷新 repo→tagIds 映射，让 selectedTagIds 多选过滤实时生效。
+            // 与 sidebar 其他统计同步刷新，避免新增/删除 tag 后 wall 多选还按旧映射过滤。
+            async let tagAssignmentsResult = repoTagRepository.fetchAllTagAssignments()
 
             self.totalCount = try await total
             self.untaggedCount = try await untagged
             self.languageStats = try await langs
             self.tags = try await tagsResult
             self.tagCounts = try await tagCountsResult
+            let assignments = try await tagAssignmentsResult
+            self.repoTagsMap = assignments.mapValues { Set($0.map(\.id)) }
+
+            // 标签被删除后，如果还在 selectedTagIds 里，过滤会变空集；这里主动收敛。
+            let validTagIds = Set(self.tags.map(\.id))
+            let stale = self.selectedTagIds.subtracting(validTagIds)
+            if !stale.isEmpty {
+                self.selectedTagIds.subtract(stale) // didSet 会触发 applyView
+            } else if !self.selectedTagIds.isEmpty {
+                // 即使 id 没变，repoTagsMap 内容可能变（刚刚打/卸标签）→ 主动 applyView
+                self.applyView()
+            }
         } catch {
             AppLog.database.error("refreshSidebar failed: \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    // MARK: - HOM-179：标签墙多选 actions
+
+    /// 切换某个 tag 在多选集合中的勾选状态。
+    ///
+    /// 实现顺序很关键：**先**修正 selection、**再**写 selectedTagIds，让最终
+    /// 一次 applyView 同时拿到对的 base set 和对的 filter，避免 SwiftUI 短暂渲染
+    /// "untagged + selectedTagIds={tag1}"这种永远空集的过渡态。
+    /// 关键约束：`Set.insert/remove` 走值语义；写回 `selectedTagIds` 时整个 Set
+    /// 被替换，didSet 一定触发。
+    func toggleSelectedTag(_ tagId: String) {
+        var next = selectedTagIds
+        if next.contains(tagId) {
+            next.remove(tagId)
+        } else {
+            next.insert(tagId)
+        }
+
+        // 选中至少一个 tag 时，强制把 selection 退回到 .allStars，避免和 .tag(legacy) /
+        // .untagged 形成"自相矛盾"组合：
+        // - .untagged + selectedTagIds 永远空集，UX 反直觉
+        // - .tag(legacy) + selectedTagIds 语义重叠（旧的单标签等价于 selectedTagIds = {legacy}）
+        // 用户后续可显式切到 .language(...) 形成 AND 组合。
+        if !next.isEmpty {
+            switch selection {
+            case .untagged, .tag:
+                selection = .allStars
+            case .allStars, .language, .trending:
+                break
+            }
+        }
+
+        selectedTagIds = next
+    }
+
+    /// 一键清空所有已选 tag。
+    /// `Set` 已为空时 didSet 会被自身 guard 阻断，不会触发不必要的 applyView。
+    func clearSelectedTags() {
+        guard !selectedTagIds.isEmpty else { return }
+        selectedTagIds = []
     }
 
     /// 重新加载中栏列表。
@@ -481,7 +567,7 @@ final class HomeViewModel {
                             return (repos: try await self.repository.searchFTS(query: self.searchQuery), semanticHitMap: [:])
                         }
                     } else {
-                        let repos: [Repo]
+                        var repos: [Repo]
                         switch self.selection {
                         case .trending:
                             repos = [] // Placeholder for W7 Trending
@@ -494,6 +580,7 @@ final class HomeViewModel {
                         case .tag(let tagId):
                             repos = try await self.repoTagRepository.fetchRepos(forTag: tagId)
                         }
+
                         return (repos: repos, semanticHitMap: [:])
                     }
                 }
@@ -723,6 +810,18 @@ final class HomeViewModel {
             view.removeAll { repo in
                 let actual = statusMap[repo.id] ?? .unread
                 return actual != status
+            }
+        }
+        // HOM-179：标签墙多选 OR 过滤。
+        // 用户口径：
+        //   - 多个 tag 之间 OR：命中任意一个就保留
+        //   - 与 selection（Languages 等）AND：因为 `view` 此时已是 selection 派生的 base set
+        // 实现：用 repoTagsMap 查每个 repo 的 tagIds，看与 selectedTagIds 是否有交集。
+        // 没有交集（即"没有任何已选 tag"）→ 移除。
+        if !selectedTagIds.isEmpty {
+            view.removeAll { repo in
+                let tagsOfRepo = repoTagsMap[repo.id] ?? []
+                return tagsOfRepo.isDisjoint(with: selectedTagIds)
             }
         }
         // 语义搜索结果的排序来自 cosine similarity；再套用户的 stars/name 排序会破坏 AI 排名。

--- a/Starcat/Features/Home/SidebarView.swift
+++ b/Starcat/Features/Home/SidebarView.swift
@@ -178,13 +178,18 @@ struct SidebarView: View {
             }
 
             // W4 A6：Tags 段。
-            // 行为：每个用户自定义标签一行，点击 → selection = .tag(id) → 列表过滤
+            // HOM-179：改为标签墙形式，横向排列自动换行；多选 OR 过滤。
             // HOM-43：折叠按钮始终可见，不依赖 hover；图标在右侧；点击整个区域可折叠
             Section {
                 if tagsExpanded && !viewModel.tags.isEmpty {
-                    ForEach(viewModel.tags) { tag in
-                        tagRow(tag: tag, count: viewModel.tagCounts[tag.id] ?? 0)
-                    }
+                    TagWallView(
+                        tags: viewModel.tags,
+                        tagCounts: viewModel.tagCounts,
+                        selectedTagIds: viewModel.selectedTagIds,
+                        onTagTap: { tagId in
+                            viewModel.toggleSelectedTag(tagId)
+                        }
+                    )
                 }
             } header: {
                 tagSectionHeader
@@ -363,6 +368,24 @@ struct SidebarView: View {
             .buttonStyle(.plain)
             .focusEffectDisabled()
             .help(disclosureHelp(isExpanded: tagsExpanded))
+
+            // HOM-179：仅当有 tag 被选中时显示"清除"按钮，避免空状态下噪声。
+            // 与 `+` / chevron 同款 14pt hierarchical 语言，hover 反馈复用 pressableHover。
+            if !viewModel.selectedTagIds.isEmpty {
+                Button {
+                    viewModel.clearSelectedTags()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 14, weight: .medium))
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 20, height: 20)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .focusEffectDisabled()
+                .help(Text("sidebar.clearSelectedTags"))
+            }
 
             Button {
                 showTagManagement = true

--- a/Starcat/Features/Home/TagWallView.swift
+++ b/Starcat/Features/Home/TagWallView.swift
@@ -1,0 +1,212 @@
+//
+//  TagWallView.swift
+//  Starcat
+//
+//  HOM-179：左侧 Tags 列表改为标签墙组件。
+//
+//  设计演进（dong4j 反馈驱动）：
+//  - v1：选中 / 未选中都 30%-50% opacity 透明背景，区分度太弱
+//  - v3：选中 = 实色底 + 自适应黑白文字；未选中 = 12% 浅底 + 同色文字
+//  - **v4（当前）**：未选中文字色改 `.primary`（系统自适应黑/白），
+//    与 swatchColor 浅底形成明显对比，且天然适配亮/暗主题；
+//    icon 仍用 swatchColor 保留 tag 身份；
+//    选中态保留 v3 的实色底 + 自适应黑白文字 + 阴影方案。
+//  - icon 始终展示：tag.icon 优先，无则 fallback 到 `tag.fill`，与 sidebar
+//    `tagRow()` 保持同款图标语言，避免标签墙 / 列表两种形态视觉割裂。
+//  - 自适应文字色：tag 实色底上的文字色按 sRGB 相对亮度自动选黑或白
+//    （阈值 0.6），避免黄色等浅 tag 出现"白字 + 黄底"无法阅读的情况。
+//
+
+import SwiftUI
+#if canImport(AppKit)
+import AppKit
+#endif
+
+// MARK: - TagWallView
+
+/// 标签墙视图：横向排列、自动换行，支持多选。
+///
+/// 调用方在 `onTagTap` 中执行 toggle 动作（建议直接调
+/// `HomeViewModel.toggleSelectedTag`），本视图不维护任何状态——
+/// `selectedTagIds` 是被动入参，更新由外部完成。
+struct TagWallView: View {
+    let tags: [Tag]
+    let tagCounts: [String: Int]
+    /// 已勾选的 tag id 集合（多选）。
+    let selectedTagIds: Set<String>
+    /// 用户点击某个 chip 时调用。调用方负责 toggle 这个 id 在集合内的勾选状态。
+    let onTagTap: (String) -> Void
+
+    var body: some View {
+        FlowLayout(spacing: 6) {
+            ForEach(tags) { tag in
+                TagWallChip(
+                    tag: tag,
+                    count: tagCounts[tag.id] ?? 0,
+                    isSelected: selectedTagIds.contains(tag.id),
+                    onTap: { onTagTap(tag.id) }
+                )
+            }
+        }
+    }
+}
+
+// MARK: - TagWallChip
+
+/// 标签墙单个标签：
+/// - 未选中：tag.color 18% 浅底 + 35% 描边；icon 用 tag.color，name 用 `.primary`，
+///   count 用 `.secondary`——颜色身份保留在 icon，文字直接走系统自适应灰阶
+///   保证亮/暗主题下都和底色清晰区分（dong4j 2026-06-07 反馈：
+///   "字体颜色和底色是一个色系，最好明显区分"）
+/// - 选中：tag.color 实色底 + 自适应黑/白文字 + 1pt 描边 + 软阴影（高对比、勾选感强）
+/// - icon 始终展示：tag.icon 优先，无则 `tag.fill`
+struct TagWallChip: View {
+    let tag: Tag
+    let count: Int
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    /// 圆角常量；放在视图外部以便 background / clipShape / overlay 共用同一个值。
+    private static let cornerRadius: CGFloat = 6
+
+    /// 标签颜色，fallback 到默认蓝色（tag.color 解析失败 / nil 时）。
+    private var swatchColor: Color {
+        Color(hex: tag.color ?? TagColorPalette.defaultHex) ?? .accentColor
+    }
+
+    /// 选中态前景色：基于 swatchColor 亮度自适应黑/白，避免黄色等浅 tag 上白字无法阅读。
+    /// 阈值 0.6 是经验值——常见 tag palette（红蓝绿紫）大都 < 0.6 → 用白字；
+    /// 黄色 / 浅绿 / 浅蓝（≥ 0.6）→ 用黑字。
+    private var selectedForeground: Color {
+        swatchColor.perceivedLuminance > 0.6 ? .black : .white
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            // 图标：tag.icon 优先，无则用 `tag.fill` 兜底，跟 sidebar tagRow 同款语言。
+            // 未选中时显式给 swatchColor，让 tag 颜色身份不被 .primary 覆盖；
+            // 选中时跟随外层 selectedForeground，保持与文字同色。
+            Image(systemName: tag.icon ?? "tag.fill")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(isSelected ? selectedForeground : swatchColor)
+
+            Text(verbatim: tag.name)
+                .font(.caption)
+                .lineLimit(1)
+
+            Text(count.formatted())
+                .font(.caption2)
+                .opacity(isSelected ? 0.85 : 1)
+                .monospacedDigit()
+                // 未选中时让计数走 .secondary 减弱视觉权重，避免和 name 同等高对比抢戏。
+                // 选中时 count 跟随 selectedForeground，0.85 透明度做层级区分。
+                .foregroundStyle(isSelected ? AnyShapeStyle(selectedForeground) : AnyShapeStyle(.secondary))
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        // 选中：实色底，强对比；未选中：18% 浅底，柔和但仍能看清边界。
+        .background {
+            RoundedRectangle(cornerRadius: Self.cornerRadius)
+                .fill(isSelected ? AnyShapeStyle(swatchColor) : AnyShapeStyle(swatchColor.opacity(0.18)))
+        }
+        // 文字色：未选中用 .primary（系统自适应黑/白），选中用 selectedForeground。
+        // 这是与底色对比的关键——.primary 不是 swatchColor，所以肯定不"同色系"。
+        .foregroundStyle(isSelected ? AnyShapeStyle(selectedForeground) : AnyShapeStyle(.primary))
+        // 描边：未选中 0.5pt 35% 同色描边，强化 chip 边界感；选中 1pt 90% 同色描边。
+        .overlay {
+            RoundedRectangle(cornerRadius: Self.cornerRadius)
+                .strokeBorder(
+                    isSelected ? swatchColor.opacity(0.9) : swatchColor.opacity(0.35),
+                    lineWidth: isSelected ? 1 : 0.5
+                )
+        }
+        // 选中态加一层柔和投影，进一步突出"已选"层级；未选中投影 radius=0 退化为无。
+        .shadow(color: swatchColor.opacity(isSelected ? 0.35 : 0), radius: 2, y: 1)
+        .contentShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
+        .onTapGesture { onTap() }
+        .pressableHover()
+        .animation(.easeOut(duration: 0.15), value: isSelected)
+    }
+}
+
+// MARK: - 颜色亮度工具
+
+fileprivate extension Color {
+    /// sRGB 相对亮度（0..1）。用于在已知色块上选择黑 / 白文字。
+    /// 公式来自 W3C WCAG：L = 0.2126R + 0.7152G + 0.0722B（线性近似，
+    /// 不做严格 gamma 反变换；对 chip 这种非长文场景足够）。
+    var perceivedLuminance: Double {
+        #if canImport(AppKit)
+        guard let ns = NSColor(self).usingColorSpace(.sRGB) else { return 0.5 }
+        return 0.2126 * Double(ns.redComponent)
+             + 0.7152 * Double(ns.greenComponent)
+             + 0.0722 * Double(ns.blueComponent)
+        #else
+        return 0.5
+        #endif
+    }
+}
+
+// MARK: - FlowLayout
+
+/// 横向排列自动换行布局，复用自 RepoTagsSection。
+private struct FlowLayout: Layout {
+    var spacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var rowWidth: CGFloat = 0
+        var totalHeight: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if rowWidth + size.width > maxWidth {
+                totalHeight += rowHeight + spacing
+                rowWidth = size.width + spacing
+                rowHeight = size.height
+            } else {
+                rowWidth += size.width + spacing
+                rowHeight = max(rowHeight, size.height)
+            }
+        }
+        totalHeight += rowHeight
+        return CGSize(width: maxWidth.isFinite ? maxWidth : rowWidth, height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let maxWidth = bounds.width
+        var x: CGFloat = bounds.minX
+        var y: CGFloat = bounds.minY
+        var rowHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x + size.width > bounds.minX + maxWidth {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    TagWallView(
+        tags: [
+            Tag(id: "1", name: "Swift", color: "#FF453A", icon: "swift", sortOrder: 0, isPreset: false, parentId: nil, createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z"),
+            Tag(id: "2", name: "JavaScript", color: "#FFD60A", icon: nil, sortOrder: 1, isPreset: false, parentId: nil, createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z"),
+            Tag(id: "3", name: "Python", color: "#30D158", icon: nil, sortOrder: 2, isPreset: false, parentId: nil, createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z"),
+            Tag(id: "4", name: "Rust", color: "#0A84FF", icon: "hammer", sortOrder: 3, isPreset: false, parentId: nil, createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z"),
+            Tag(id: "5", name: "Go", color: "#66D4CF", icon: nil, sortOrder: 4, isPreset: false, parentId: nil, createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z"),
+        ],
+        tagCounts: ["1": 42, "2": 28, "3": 15, "4": 8, "5": 3],
+        selectedTagIds: ["1", "3"],
+        onTagTap: { _ in }
+    )
+    .frame(width: 280)
+    .padding()
+}

--- a/Starcat/Resources/Localizable.xcstrings
+++ b/Starcat/Resources/Localizable.xcstrings
@@ -9154,6 +9154,22 @@
         }
       }
     },
+    "sidebar.clearSelectedTags" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Selected Tags"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除已选标签"
+          }
+        }
+      }
+    },
     "sidebar.tags" : {
       "localizations" : {
         "en" : {


### PR DESCRIPTION
关联 issue：[HOM-179](https://github.com/dong4j/Starcat/issues/HOM-179)

## Summary

把左侧 Manage 页 Tags 列表改造为**标签墙**，并实现 dong4j 反复迭代后定型的过滤语义：

- **标签墙**：横向自动换行（FlowLayout），每个 chip 展示 SF Symbol 图标 + 名字 + 计数
- **多选 OR**：勾多个 tag 时 OR（命中任一即保留）
- **与 Languages AND**：标签 OR 集合与 selection（Languages / All Stars / Untagged）形成 AND 组合
- **清除按钮**：Tags header 在有勾选时显示 `xmark.circle.fill` 一键清空
- **Chip 视觉强化**：未选中走 `.primary` 文字（系统自适应、不同色系），选中走 tag.color 实色底 + 自适应黑/白文字（基于 sRGB 亮度阈值 0.6 避免浅色 tag + 白字不可读）

## 关键设计决策

1. **多选 tag 是独立 filter，不入侵 `SidebarItem`**：新增 `HomeViewModel.selectedTagIds: Set<String>`，通过 `applyView()` 在 base set（selection 派生）上做 OR 过滤。这样切 Languages / All Stars 时 selection 走原有路径（含 cache + SWR + 抖动修复），多选状态自然 AND 叠加。
2. **OR 过滤走全量内存映射，不发起新 SQL**：`refreshSidebar()` 一次拉 `repoTagsMap: [Int64: Set<String>]`（约几千条，<100KB），勾/取消标签时无 DB 查询，UI 即时响应。与现有 `statusMap` 全表加载 + applyView 过滤的路径一致。
3. **selection ↔ selectedTagIds 协调**：勾第一个 tag 时若 selection 是 `.untagged` 或 `.tag(legacy)`（永远空集 / 语义重叠），会自动收敛到 `.allStars`，避免反直觉的"untagged + tag={x}"组合。
4. **Chip 自适应文字色**：选中态用 `swatchColor.perceivedLuminance > 0.6 ? .black : .white`（W3C WCAG 相对亮度公式线性近似），保证黄/浅蓝等浅色 tag 上文字仍可读。

## 不动的部分（surgical）

- `SidebarItem.tag(id)` 单选 case 保留（持久化兼容），UI 不再使用
- 既有 row()/tagRow()/languageRow() 抖动修复、cache、SWR、prefetch 路径完全不变
- 既有 `fetchRepos(forTag:)` / `fetchRepos(forTags:)` 单/多 AND 查询保留（导出等场景仍可能用）

## 文件变更

- 新增 `Starcat/Features/Home/TagWallView.swift`：`TagWallView` / `TagWallChip` / `FlowLayout` + `Color.perceivedLuminance` fileprivate extension
- 修改 `Starcat/Features/Home/HomeViewModel.swift`：新增 `selectedTagIds` / `repoTagsMap` / `toggleSelectedTag` / `clearSelectedTags`，`refreshSidebar` 同步 tag 映射并收敛过期 id，`applyView` 内做 OR 过滤
- 修改 `Starcat/Features/Home/SidebarView.swift`：Tags Section 改用 `TagWallView`，header 加"清除"按钮
- 修改 `Starcat/Core/Sync/RepoTagRepository*.swift`：补 `fetchRepos(forTags:)` 多标签 AND 查询（备用，本 PR UI 未走，但导出等路径可能用到）
- 修改 `Starcat/Resources/Localizable.xcstrings`：新增 `sidebar.clearSelectedTags` 中英文案

## Test plan

dong4j 在 v4 binary 上已逐项验证通过：

- [x] 仅 tag1 → 含 tag1 的 repo
- [x] tag1 + tag2 → 含 tag1 或 tag2 的 repo（OR）
- [x] Java + tag1 + tag2 → Java 且（tag1 或 tag2）的 repo（语言 AND 标签 OR）
- [x] 只选 Java → 全部 Java repo（不受标签影响）
- [x] 切回 All Stars，标签保留 → 全部 Stars 中含已选 tag 的 repo
- [x] 清除按钮一键清空多选
- [x] 勾掉最后一个标签后 → 回到当前 selection 全集
- [x] 标签墙在面板宽度变化时自动调整每行标签数量
- [x] 移动端 / 窄宽度布局正常
- [x] 文字与底色对比明显，亮/暗主题下都清晰
- [x] 标签 SF Symbol 图标正确显示


Made with [Cursor](https://cursor.com)