### PR TITLE
feat(activity): Weekly 周刊分类 + 阮一峰周刊后端 API 接入 [MUL-176]

### DIFF
--- a/Starcat/App/AppDependencies.swift
+++ b/Starcat/App/AppDependencies.swift
@@ -85,6 +85,12 @@ final class AppDependencies {
     /// W7+ 引入：Trending README 持久化（与 manage 路径独立的 `trending_readmes` 表）。
     let trendingReadmeRepository: TrendingReadmeRepository
 
+    // MARK: - MUL-176 Weekly（阮一峰周刊）
+
+    /// 阮一峰周刊后端 API 客户端。
+    /// 独立 actor，无需 GitHub OAuth；Activity 页 `weekly` 分类直接消费。
+    let weeklyAPI: WeeklyAPI
+
     // MARK: - HOM-47 Release 订阅追踪
 
     /// Release 订阅记录 Repository。
@@ -231,6 +237,11 @@ final class AppDependencies {
 
         // HOM-54：Trending Repository（W7+ 起接入 GRDB 持久化）
         self.trendingRepository = TrendingRepository(database: db)
+
+        // MUL-176：阮一峰周刊 API 客户端。
+        // 默认走生产域名 starcat-weekly-api.fly.dev，需要 mock 或本地联调时
+        // 在测试 / Preview 路径里改造为传入自定义 baseURL。
+        self.weeklyAPI = WeeklyAPI()
 
         // HOM-47：Release 订阅追踪。
         // 装配顺序：Repository → Monitor（依赖 API + Repository + RepoRepository）

--- a/Starcat/Core/Network/WeeklyAPI.swift
+++ b/Starcat/Core/Network/WeeklyAPI.swift
@@ -1,0 +1,203 @@
+//
+//  WeeklyAPI.swift
+//  Starcat
+//
+//  阮一峰周刊后端 API 客户端。
+//
+//  数据源：starcat-weekly-api（独立 Go 服务）
+//  契约：见 https://github.com/dong4j/starcat-weekly-api 的 README，与
+//  本文件配套设计。
+//
+//  设计约束：
+//  - 与 `TrendingAPI` 保持同款 actor + URLSession 风格，不引第三方 HTTP 库；
+//  - 不需要 GitHub OAuth，独立 URLSession，错误映射到 `WeeklyAPIError`；
+//  - baseURL 默认指向生产域名（fly.io），允许构造时覆盖以便单测 / Preview 注入。
+//
+
+import Foundation
+
+/// Weekly API 网络错误。
+enum WeeklyAPIError: Error, LocalizedError {
+    case invalidURL
+    case transport(underlying: Error)
+    case decodingError(underlying: Error)
+    case serverError(message: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return String(localized: "network.error.invalidURL")
+        case .transport(let error):
+            return String(format: String(localized: "network.error.transportFormat"), error.localizedDescription)
+        case .decodingError(let error):
+            return String(format: String(localized: "network.error.decodingFormat"), error.localizedDescription)
+        case .serverError(let message):
+            return message ?? String(localized: "network.error.serverGeneric")
+        }
+    }
+}
+
+/// 周刊后端 API 客户端。
+///
+/// 用 `actor` 隔离 URLSession + JSONDecoder 的并发访问；公共方法是 async，
+/// 与 TrendingAPI 完全一致，方便 ViewModel 同一种 await 风格调用。
+actor WeeklyAPI {
+
+    // MARK: - Constants
+
+    /// 列表请求超时；后端首次启动时会 git clone ruanyf/weekly（可能数十秒），
+    /// 但这只影响 `/internal/sync`，正常列表查询是本地 SQLite 命中，30s 充裕。
+    private static let timeout: TimeInterval = 30
+
+    /// 默认每页大小，与后端 README 默认值保持一致；UI 层不复写。
+    static let defaultPageSize: Int = 20
+
+    // MARK: - Properties
+
+    private let baseURL: URL
+    private let session: URLSession
+    private let decoder: JSONDecoder
+
+    // MARK: - Initialization
+
+    /// - Parameters:
+    ///   - baseURL: 后端域名；默认走 fly.io 生产环境，命名与 `starcat-trending-api`
+    ///     保持一致的子域前缀，部署时只需把 `weekly` 子域挂上即可。
+    ///   - session: 注入自定义 URLSession（一般用于单测 mock）；为 nil 走默认配置。
+    init(
+        baseURL: URL = URL(string: "https://starcat-weekly-api.fly.dev")!,
+        session: URLSession? = nil
+    ) {
+        self.baseURL = baseURL
+        if let session {
+            self.session = session
+        } else {
+            let config = URLSessionConfiguration.default
+            config.timeoutIntervalForRequest = Self.timeout
+            config.timeoutIntervalForResource = Self.timeout
+            self.session = URLSession(configuration: config)
+        }
+
+        // 与 TrendingAPI 同理：上游 JSON 含 snake_case，所有键都已通过 CodingKeys 显式映射，
+        // 这里**不要**开 `.convertFromSnakeCase`，否则会先把 key 转成 camelCase，
+        // 反而无法匹配 `CodingKeys = "snake_key"`。
+        let decoder = JSONDecoder()
+        self.decoder = decoder
+    }
+
+    // MARK: - Public API
+
+    /// 拉取周刊项目分页列表。
+    ///
+    /// - Parameters:
+    ///   - page: 页码，从 1 开始。
+    ///   - pageSize: 每页大小。
+    ///   - issue: 期号筛选；`.all` 不传该参数。
+    ///   - language: 语言筛选；nil 或空串等价于不筛选。
+    ///   - sort: 排序方式。
+    /// - Returns: 项目列表 + 分页元数据。
+    func fetchProjects(
+        page: Int = 1,
+        pageSize: Int = WeeklyAPI.defaultPageSize,
+        issue: WeeklyIssueFilter = .all,
+        language: String? = nil,
+        sort: WeeklySort = .firstIssueDesc
+    ) async throws -> WeeklyProjectListResult {
+        let url = try buildProjectsURL(page: page, pageSize: pageSize, issue: issue, language: language, sort: sort)
+        let data = try await performRequest(url: url)
+        let dto: WeeklyProjectListDTO
+        do {
+            dto = try decoder.decode(WeeklyProjectListDTO.self, from: data)
+        } catch {
+            throw WeeklyAPIError.decodingError(underlying: error)
+        }
+        return WeeklyProjectListResult(
+            items: dto.items.map(WeeklyProject.init(dto:)),
+            total: dto.total,
+            page: dto.page,
+            pageSize: dto.pageSize
+        )
+    }
+
+    // MARK: - Private
+
+    private func buildProjectsURL(
+        page: Int,
+        pageSize: Int,
+        issue: WeeklyIssueFilter,
+        language: String?,
+        sort: WeeklySort
+    ) throws -> URL {
+        var components = URLComponents(url: baseURL.appendingPathComponent("api/weekly/projects"), resolvingAgainstBaseURL: false)
+        var queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "page", value: String(page)),
+            URLQueryItem(name: "page_size", value: String(pageSize)),
+            URLQueryItem(name: "sort", value: sort.apiValue)
+        ]
+        if let issueValue = issue.apiValue {
+            queryItems.append(URLQueryItem(name: "issue", value: issueValue))
+        }
+        if let language, !language.isEmpty {
+            queryItems.append(URLQueryItem(name: "lang", value: language))
+        }
+        components?.queryItems = queryItems
+        guard let url = components?.url else {
+            throw WeeklyAPIError.invalidURL
+        }
+        return url
+    }
+
+    private func performRequest(url: URL) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Starcat/1.0", forHTTPHeaderField: "User-Agent")
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            return try validateResponse(data: data, response: response)
+        } catch let error as WeeklyAPIError {
+            throw error
+        } catch {
+            throw WeeklyAPIError.transport(underlying: error)
+        }
+    }
+
+    private func validateResponse(data: Data, response: URLResponse) throws -> Data {
+        guard let http = response as? HTTPURLResponse else {
+            throw WeeklyAPIError.transport(underlying: URLError(.badServerResponse))
+        }
+        switch http.statusCode {
+        case 200...299:
+            return data
+        case 400...499:
+            let message = String(data: data, encoding: .utf8)
+            throw WeeklyAPIError.serverError(message: message)
+        case 500...599:
+            throw WeeklyAPIError.serverError(
+                message: String(format: String(localized: "network.error.serverStatusFormat"), http.statusCode)
+            )
+        default:
+            throw WeeklyAPIError.transport(underlying: URLError(.badServerResponse))
+        }
+    }
+}
+
+// MARK: - Result
+
+/// 列表查询的领域级返回：DTO 已转成 `WeeklyProject`，分页元数据原样透传。
+///
+/// 单独抽出来而不是直接复用 DTO，是为了让 ViewModel 不依赖 `Decodable` 类型，
+/// 后续若做缓存层（GRDB）替换，签名也不用动。
+struct WeeklyProjectListResult: Equatable {
+    let items: [WeeklyProject]
+    let total: Int
+    let page: Int
+    let pageSize: Int
+
+    /// 是否还有下一页：根据 total / page / pageSize 推算，避免 ViewModel 自算出错。
+    var hasMore: Bool {
+        guard pageSize > 0 else { return false }
+        return page * pageSize < total
+    }
+}

--- a/Starcat/Core/Network/WeeklyModels.swift
+++ b/Starcat/Core/Network/WeeklyModels.swift
@@ -1,0 +1,150 @@
+//
+//  WeeklyModels.swift
+//  Starcat
+//
+//  阮一峰周刊（ruanyf/weekly）后端 API 的响应 DTO 与领域模型。
+//
+//  数据源：starcat-weekly-api（独立 Go 服务，见 https://github.com/dong4j/starcat-weekly-api）
+//  上游 API 返回纯 JSON（与 starcat-sharing-api 同款风格，无 code 包装）。
+//
+//  设计约束：
+//  - DTO 字段名与后端 JSON 保持一致（snake_case），通过 CodingKeys 显式映射，
+//    与 TrendingModels 保持同款做法：不开 `.convertFromSnakeCase`，避免与
+//    显式 CodingKeys 冲突。
+//  - 领域模型由 DTO 构造，UI 层只关心领域模型。
+//
+
+import Foundation
+
+// MARK: - API Response
+
+/// `/api/weekly/projects` 响应 DTO（外层包装）。
+struct WeeklyProjectListDTO: Decodable {
+    let items: [WeeklyProjectDTO]
+    let total: Int
+    let page: Int
+    let pageSize: Int
+
+    enum CodingKeys: String, CodingKey {
+        case items
+        case total
+        case page
+        case pageSize = "page_size"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.items = try container.decodeIfPresent([WeeklyProjectDTO].self, forKey: .items) ?? []
+        self.total = try container.decodeIfPresent(Int.self, forKey: .total) ?? 0
+        self.page = try container.decodeIfPresent(Int.self, forKey: .page) ?? 1
+        self.pageSize = try container.decodeIfPresent(Int.self, forKey: .pageSize) ?? 20
+    }
+}
+
+/// 单个项目 DTO。
+struct WeeklyProjectDTO: Decodable {
+    let owner: String
+    let repo: String
+    let url: String
+    let description: String?
+    let stars: Int
+    let language: String?
+    let firstIssue: Int
+    let issueUrl: String
+
+    enum CodingKeys: String, CodingKey {
+        case owner
+        case repo
+        case url
+        case description
+        case stars
+        case language
+        case firstIssue = "first_issue"
+        case issueUrl = "issue_url"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.owner = try container.decode(String.self, forKey: .owner)
+        self.repo = try container.decode(String.self, forKey: .repo)
+        self.url = try container.decode(String.self, forKey: .url)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.stars = try container.decodeIfPresent(Int.self, forKey: .stars) ?? 0
+        self.language = try container.decodeIfPresent(String.self, forKey: .language)
+        self.firstIssue = try container.decodeIfPresent(Int.self, forKey: .firstIssue) ?? 0
+        self.issueUrl = try container.decodeIfPresent(String.self, forKey: .issueUrl) ?? ""
+    }
+}
+
+// MARK: - Domain Model
+
+/// 周刊推荐项目领域模型，UI 直接消费。
+///
+/// 与 DTO 拆开是为了：
+/// 1. 把字符串 URL 转成 `URL`，避免每个调用点都 `URL(string:)`；
+/// 2. 提供 `fullName` 这种派生字段，让 UI 写法更简洁；
+/// 3. 后续若加入 AI 摘要、订阅状态等 UI 专属字段，不污染网络层 DTO。
+struct WeeklyProject: Identifiable, Equatable {
+    /// 用 owner/repo 作 id：同一仓库不论在多少期出现，UI 都按"项目"维度去重展示。
+    var id: String { fullName }
+
+    let owner: String
+    let name: String
+    let url: URL
+    let description: String?
+    let stars: Int
+    let language: String?
+    /// 项目第一次被周刊收录的期号；用来在 row 上展示"第 NNN 期推荐"。
+    let firstIssue: Int
+    /// 第一次收录的原始 md URL，方便用户跳到周刊原文上下文。
+    let issueURL: URL?
+
+    var fullName: String { "\(owner)/\(name)" }
+
+    init(dto: WeeklyProjectDTO) {
+        self.owner = dto.owner
+        self.name = dto.repo
+        self.url = URL(string: dto.url) ?? URL(string: "https://github.com/\(dto.owner)/\(dto.repo)")!
+        self.description = dto.description
+        self.stars = dto.stars
+        self.language = dto.language
+        self.firstIssue = dto.firstIssue
+        self.issueURL = dto.issueUrl.isEmpty ? nil : URL(string: dto.issueUrl)
+    }
+}
+
+// MARK: - Query parameters
+
+/// 排序枚举，与后端 `sort` 参数一一对应。
+///
+/// 故意只暴露两个用户视角清晰的选项：
+/// - "最新收录"：以期号倒序，用户能持续看到最近一期开始的项目；
+/// - "Stars 最多"：把口碑积累的项目顶到前面，便于发现稳定推荐。
+enum WeeklySort: String, CaseIterable, Identifiable {
+    case firstIssueDesc = "first_issue_desc"
+    case starsDesc = "stars_desc"
+
+    var id: String { rawValue }
+    var apiValue: String { rawValue }
+}
+
+/// 期号筛选；`all` 不传 issue 参数，对应"全部期号"。
+///
+/// 用结构体而非 enum，是为了让"任意期号"成为可参数化值，避免 enum 退化成
+/// `case n(Int)` 后还得在 UI 里特殊处理"selected case"。
+struct WeeklyIssueFilter: Hashable, Identifiable {
+    /// nil = 全部期号；非 nil = 指定期号。
+    let issueNumber: Int?
+
+    var id: String {
+        if let n = issueNumber { return "issue:\(n)" }
+        return "issue:all"
+    }
+
+    var apiValue: String? {
+        guard let n = issueNumber else { return nil }
+        return String(n)
+    }
+
+    static let all = WeeklyIssueFilter(issueNumber: nil)
+}

--- a/Starcat/Features/Activity/ActivityModels.swift
+++ b/Starcat/Features/Activity/ActivityModels.swift
@@ -29,6 +29,12 @@ enum ActivityCategory: String, CaseIterable, Identifiable, Sendable {
     case repository
     case following
     case suggestion
+    /// MUL-176：阮一峰周刊（ruanyf/weekly）推荐 GitHub 项目聚合。
+    ///
+    /// 与其他分类不同，weekly 的数据源不是本地 Repo 缓存，而是独立的远端 REST API
+    /// （starcat-weekly-api）。因此 ActivityView 在选中此分类时会切换到
+    /// `WeeklyContentView`，不复用 ActivityViewModel 的本地聚合逻辑。
+    case weekly
 
     var id: String { rawValue }
 
@@ -41,6 +47,7 @@ enum ActivityCategory: String, CaseIterable, Identifiable, Sendable {
         case .repository:   return "activity.category.repository"
         case .following:    return "activity.category.following"
         case .suggestion:   return "activity.category.suggestion"
+        case .weekly:       return "activity.category.weekly"
         }
     }
 
@@ -53,6 +60,7 @@ enum ActivityCategory: String, CaseIterable, Identifiable, Sendable {
         case .repository:   return String(localized: "activity.category.repository")
         case .following:    return String(localized: "activity.category.following")
         case .suggestion:   return String(localized: "activity.category.suggestion")
+        case .weekly:       return String(localized: "activity.category.weekly")
         }
     }
 
@@ -67,6 +75,7 @@ enum ActivityCategory: String, CaseIterable, Identifiable, Sendable {
         case .repository:   return "#A97BFF" // Kotlin purple
         case .following:    return "#701516" // Ruby deep red
         case .suggestion:   return "#3178c6" // TypeScript blue
+        case .weekly:       return "#dea584" // Rust beige —— 与上面 7 色都不撞，且与"周刊"温和气质相符
         }
     }
 
@@ -84,6 +93,7 @@ enum ActivityCategory: String, CaseIterable, Identifiable, Sendable {
         case .repository:   return "folder"
         case .following:    return "person.2"
         case .suggestion:   return "sparkles"
+        case .weekly:       return "newspaper"
         }
     }
 }

--- a/Starcat/Features/Activity/ActivityView.swift
+++ b/Starcat/Features/Activity/ActivityView.swift
@@ -26,7 +26,11 @@ struct ActivityView: View {
 
     var body: some View {
         Group {
-            if let viewModel {
+            // MUL-176：weekly 分类是远端分页数据，与本地聚合的其它分类完全不同源，
+            // 所以这里整体切到 `WeeklyContentView`，绕开 ActivityViewModel 的本地路径。
+            if selectedCategory == .weekly {
+                WeeklyContentView()
+            } else if let viewModel {
                 content(viewModel)
             } else {
                 ProgressView()
@@ -34,6 +38,9 @@ struct ActivityView: View {
             }
         }
         .task(id: selectedCategory) {
+            // weekly 分类的数据加载由 WeeklyContentView 自行 .task 触发，
+            // 这里不该再去走 ActivityViewModel.load，否则会做无意义的本地聚合。
+            guard selectedCategory != .weekly else { return }
             let model = ensureViewModel()
             await model.load(category: selectedCategory)
             restoreSelection(from: model.items)

--- a/Starcat/Features/Activity/WeeklyContentView.swift
+++ b/Starcat/Features/Activity/WeeklyContentView.swift
@@ -1,0 +1,526 @@
+//
+//  WeeklyContentView.swift
+//  Starcat
+//
+//  Activity 页 `weekly` 分类的中栏视图 + ViewModel。
+//
+//  数据源：阮一峰周刊（ruanyf/weekly）通过独立 Go 后端服务暴露的 REST API。
+//  契约见 `WeeklyAPI.swift` / 后端仓库 README。
+//
+//  设计约束：
+//  - 不复用 ActivityViewModel 的本地聚合逻辑：weekly 是远端分页 + 筛选 + 排序，
+//    塞进 ActivityViewModel 会污染其"本地缓存聚合"语义。
+//  - 列表点击 → 直接外链跳转 GitHub（用 NSWorkspace），不进右侧 detail pane，
+//    因为这些项目都是用户没 star 过的远端项目，本地 Repo 缓存里没有对应记录，
+//    复用 ActivityDetailView 会撞空，反而误导用户。
+//  - 分页是"无限滚动"：到达列表底部时自动加载下一页；不放手动"加载更多"按钮，
+//    与 macOS 上 List 的自然滚动体验一致。
+//
+
+import SwiftUI
+import AppKit
+
+// MARK: - View
+
+/// Activity 页 weekly 分类的内容视图。
+struct WeeklyContentView: View {
+
+    @Environment(AppDependencies.self) private var dependencies
+    @Environment(AppSettings.self) private var settings
+
+    @State private var viewModel: WeeklyContentViewModel?
+
+    var body: some View {
+        Group {
+            if let viewModel {
+                content(viewModel)
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .task {
+            let model = ensureViewModel()
+            await model.loadInitialIfNeeded()
+        }
+    }
+
+    @ViewBuilder
+    private func content(_ viewModel: WeeklyContentViewModel) -> some View {
+        VStack(spacing: 0) {
+            filterBar(viewModel)
+                .padding(.horizontal, 14)
+                .padding(.top, 8)
+                .padding(.bottom, 6)
+
+            Divider()
+
+            if viewModel.isLoading && viewModel.items.isEmpty {
+                RepoSkeletonListView(density: settings.listDensity, rowCount: 8)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = viewModel.loadError, viewModel.items.isEmpty {
+                emptyState(systemImage: "exclamationmark.triangle", title: "activity.error.title", subtitleText: error) {
+                    Task { await viewModel.reload() }
+                }
+            } else if viewModel.items.isEmpty {
+                emptyState(systemImage: "newspaper", title: "weekly.empty.title", subtitle: "weekly.empty.subtitle") {
+                    Task { await viewModel.reload() }
+                }
+            } else {
+                projectList(viewModel)
+            }
+        }
+    }
+
+    // MARK: - Filter Bar
+
+    /// 顶部筛选栏：排序 + 语言下拉。
+    ///
+    /// 期号筛选目前没有用 picker 暴露——后端 `/issues` 还在补，列表也不强需要；
+    /// 后续要做时增加一个 Menu 即可，结构上已经在 ViewModel 留了 `selectedIssue`。
+    private func filterBar(_ viewModel: WeeklyContentViewModel) -> some View {
+        HStack(spacing: 10) {
+            Picker(selection: Binding(
+                get: { viewModel.selectedSort },
+                set: { viewModel.changeSort(to: $0) }
+            )) {
+                ForEach(WeeklySort.allCases) { sort in
+                    Text(sort.localizedTitle).tag(sort)
+                }
+            } label: {
+                Text("weekly.filter.sort")
+            }
+            .pickerStyle(.menu)
+            .fixedSize()
+
+            Picker(selection: Binding(
+                get: { viewModel.selectedLanguage },
+                set: { viewModel.changeLanguage(to: $0) }
+            )) {
+                ForEach(WeeklyContentViewModel.languageOptions, id: \.self) { lang in
+                    Text(languageDisplayName(lang)).tag(lang)
+                }
+            } label: {
+                Text("weekly.filter.language")
+            }
+            .pickerStyle(.menu)
+            .fixedSize()
+
+            Spacer()
+
+            if let total = viewModel.totalText {
+                Text(total)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button {
+                Task { await viewModel.reload() }
+            } label: {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.caption)
+            }
+            .buttonStyle(.plain)
+            .focusEffectDisabled()
+            .disabled(viewModel.isLoading)
+            .help("weekly.refresh")
+        }
+    }
+
+    private func languageDisplayName(_ raw: String) -> String {
+        if raw.isEmpty {
+            return String(localized: "weekly.filter.allLanguages")
+        }
+        return raw
+    }
+
+    // MARK: - Project List
+
+    private func projectList(_ viewModel: WeeklyContentViewModel) -> some View {
+        List {
+            ForEach(Array(viewModel.items.enumerated()), id: \.element.id) { index, project in
+                Button {
+                    open(project.url)
+                } label: {
+                    WeeklyProjectRow(project: project, density: settings.listDensity)
+                }
+                .buttonStyle(.plain)
+                .focusEffectDisabled()
+                .contextMenu {
+                    Button(action: { open(project.url) }) {
+                        Text("weekly.action.openRepo")
+                    }
+                    if let issueURL = project.issueURL {
+                        Button(action: { open(issueURL) }) {
+                            Text("weekly.action.openIssue")
+                        }
+                    }
+                    Button(action: { copy(project.url.absoluteString) }) {
+                        Text("weekly.action.copyURL")
+                    }
+                }
+                .listRowReveal(index: index, snapshotID: viewModel.itemsRevision)
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+                .onAppear {
+                    // 到达接近底部时触发下一页：用倒数第 3 行作触发点，给网络一点提前量，
+                    // 避免用户滚到最后一行才看到 ProgressView。
+                    if viewModel.shouldTriggerLoadMore(at: index) {
+                        Task { await viewModel.loadMoreIfNeeded() }
+                    }
+                }
+            }
+
+            if viewModel.isLoadingMore {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .controlSize(.small)
+                    Spacer()
+                }
+                .padding(.vertical, 8)
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+            }
+        }
+        .listStyle(.inset)
+        .alternatingRowBackgrounds()
+    }
+
+    // MARK: - Helpers
+
+    private func ensureViewModel() -> WeeklyContentViewModel {
+        if let viewModel { return viewModel }
+        let model = WeeklyContentViewModel(api: dependencies.weeklyAPI)
+        viewModel = model
+        return model
+    }
+
+    private func open(_ url: URL) {
+        NSWorkspace.shared.open(url)
+    }
+
+    private func copy(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+
+    /// 空 / 错误状态视图。
+    /// retry 闭包给 Button 直接调用，错误态需要"重试"，空态默认只是再刷一次。
+    private func emptyState(
+        systemImage: String,
+        title: LocalizedStringKey,
+        subtitle: LocalizedStringKey? = nil,
+        subtitleText: String? = nil,
+        retry: (() -> Void)? = nil
+    ) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: systemImage)
+                .font(.system(size: 36))
+                .foregroundStyle(.tertiary)
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            if let subtitle {
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+            } else if let subtitleText {
+                Text(verbatim: subtitleText)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+            }
+            if let retry {
+                Button(action: retry) {
+                    Text("weekly.action.retry")
+                }
+                .controlSize(.small)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}
+
+// MARK: - Row
+
+private struct WeeklyProjectRow: View {
+    let project: WeeklyProject
+    let density: RepoListDensity
+
+    private var accentColor: Color {
+        if let language = project.language, !language.isEmpty {
+            return LanguageColor.color(for: language)
+        }
+        return ActivityCategory.weekly.iconColor
+    }
+
+    var body: some View {
+        switch density {
+        case .compact:
+            compact
+        case .card:
+            card
+        }
+    }
+
+    private var compact: some View {
+        HStack(spacing: 10) {
+            RemoteAvatar(
+                urlString: RepoAvatarURL.from(owner: project.owner),
+                size: 22,
+                showBorder: false
+            )
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: project.fullName)
+                    .font(.system(size: 13, weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if let desc = project.description, !desc.isEmpty {
+                    Text(verbatim: desc)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            Spacer(minLength: 8)
+            StarsBadge(count: project.stars, style: .compact)
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 8)
+    }
+
+    private var card: some View {
+        HStack(alignment: .top, spacing: 12) {
+            RemoteAvatar(
+                urlString: RepoAvatarURL.from(owner: project.owner),
+                size: 40
+            )
+            VStack(alignment: .leading, spacing: 6) {
+                Text(verbatim: project.fullName)
+                    .font(.system(size: 13, weight: .semibold))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if let desc = project.description, !desc.isEmpty {
+                    Text(verbatim: desc)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                HStack(spacing: 8) {
+                    if let language = project.language, !language.isEmpty {
+                        LanguageBadge(language: language, style: .full)
+                    }
+                    StarsBadge(count: project.stars, style: .full)
+                    if project.firstIssue > 0 {
+                        MetaBadge(
+                            systemImage: "newspaper",
+                            text: String(format: String(localized: "weekly.issueLabelFormat"), project.firstIssue),
+                            tint: accentColor
+                        )
+                    }
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 10)
+        .background {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(accentColor.opacity(0.045))
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(accentColor.opacity(0.10), lineWidth: 1)
+        }
+    }
+}
+
+// MARK: - ViewModel
+
+/// Weekly 分类专用 ViewModel。
+///
+/// 设计要点：
+/// - 单一桶（sort + language 组合），切换筛选会清空当前项目并从 page=1 重新拉；
+/// - 分页采用追加式：滚到底部触发 `loadMoreIfNeeded`，把新 page 追加到 items 尾部；
+/// - `itemsRevision` 与 Activity / Trending 同款语义：用于 `listRowReveal` 决定是否
+///   重播入场动画——筛选切换 / 重新加载时 bump，分页追加时**不** bump。
+@MainActor
+@Observable
+final class WeeklyContentViewModel {
+
+    /// 语言筛选选项：取 ruanyf/weekly 中常见的几种主语言；后端 lang 参数大小写敏感，
+    /// 这里全部用 GitHub Linguist 规范写法。
+    /// 空串代表"全部语言"，与后端 `lang` 参数留空等价。
+    static let languageOptions: [String] = [
+        "",
+        "TypeScript",
+        "JavaScript",
+        "Python",
+        "Go",
+        "Rust",
+        "Swift",
+        "Java",
+        "Kotlin",
+        "C",
+        "C++",
+        "Shell"
+    ]
+
+    // MARK: - State
+
+    private(set) var items: [WeeklyProject] = []
+    private(set) var total: Int = 0
+    private(set) var page: Int = 1
+    private(set) var hasMore: Bool = false
+
+    private(set) var isLoading: Bool = false
+    private(set) var isLoadingMore: Bool = false
+    private(set) var loadError: String?
+    /// 入场动画 / row-reveal 用的"身份快照"版本，仅在筛选切换 / 重新加载时 bump。
+    private(set) var itemsRevision: Int = 0
+
+    /// 排序当前值；setter 由 `changeSort(to:)` 控制以保证副作用统一。
+    private(set) var selectedSort: WeeklySort = .firstIssueDesc
+    private(set) var selectedLanguage: String = ""
+    /// 期号筛选；目前 UI 没暴露，保留以便后续接入"按期号"侧栏交互。
+    private(set) var selectedIssue: WeeklyIssueFilter = .all
+
+    // MARK: - Dependencies
+
+    private let api: WeeklyAPI
+    /// 标记当前 in-flight 请求的代次；切换筛选 / reload 时 bump，
+    /// 旧请求即便回来也会因为代次不匹配而被丢弃，避免顺序错乱。
+    private var generation: Int = 0
+
+    init(api: WeeklyAPI) {
+        self.api = api
+    }
+
+    // MARK: - Public
+
+    /// 首次进入页面调用；如果已有数据就跳过，避免重新进入时把缓存丢掉。
+    func loadInitialIfNeeded() async {
+        guard items.isEmpty, !isLoading else { return }
+        await reload()
+    }
+
+    /// 主动刷新：清空当前数据，从第一页重新拉。
+    func reload() async {
+        let myGen = bumpGeneration()
+        isLoading = true
+        isLoadingMore = false
+        loadError = nil
+
+        do {
+            let result = try await api.fetchProjects(
+                page: 1,
+                pageSize: WeeklyAPI.defaultPageSize,
+                issue: selectedIssue,
+                language: selectedLanguage,
+                sort: selectedSort
+            )
+            guard myGen == generation else { return }
+            items = result.items
+            total = result.total
+            page = result.page
+            hasMore = result.hasMore
+            itemsRevision += 1
+        } catch {
+            guard myGen == generation else { return }
+            loadError = error.localizedDescription
+            items = []
+            total = 0
+            hasMore = false
+        }
+        if myGen == generation {
+            isLoading = false
+        }
+    }
+
+    /// 滚到底部触发的"加载下一页"。
+    func loadMoreIfNeeded() async {
+        guard hasMore, !isLoading, !isLoadingMore else { return }
+        let myGen = generation
+        isLoadingMore = true
+        defer {
+            if myGen == generation {
+                isLoadingMore = false
+            }
+        }
+
+        let nextPage = page + 1
+        do {
+            let result = try await api.fetchProjects(
+                page: nextPage,
+                pageSize: WeeklyAPI.defaultPageSize,
+                issue: selectedIssue,
+                language: selectedLanguage,
+                sort: selectedSort
+            )
+            guard myGen == generation else { return }
+            // 同 id 项目可能因为后端排序变动并发出现重复，去一次重保险。
+            let existingIDs = Set(items.map(\.id))
+            let appended = result.items.filter { !existingIDs.contains($0.id) }
+            items.append(contentsOf: appended)
+            page = result.page
+            total = result.total
+            hasMore = result.hasMore
+        } catch {
+            guard myGen == generation else { return }
+            loadError = error.localizedDescription
+            // 分页失败保留已有数据；hasMore 暂时关掉，避免反复触发同一坏请求。
+            hasMore = false
+        }
+    }
+
+    func changeSort(to newValue: WeeklySort) {
+        guard newValue != selectedSort else { return }
+        selectedSort = newValue
+        Task { await reload() }
+    }
+
+    func changeLanguage(to newValue: String) {
+        guard newValue != selectedLanguage else { return }
+        selectedLanguage = newValue
+        Task { await reload() }
+    }
+
+    /// 给 List `.onAppear` 判断是否该触发下一页。
+    /// 倒数第 3 行（或最后一行不足 3 时直接最后一行）触发，留一点网络余量。
+    func shouldTriggerLoadMore(at index: Int) -> Bool {
+        guard hasMore, !isLoading, !isLoadingMore else { return false }
+        let threshold = max(items.count - 3, 0)
+        return index >= threshold
+    }
+
+    /// 顶部右侧显示"x 项"的友好文本；total 为 0 时返回 nil 让 UI 隐藏。
+    var totalText: String? {
+        guard total > 0 else { return nil }
+        return String(format: String(localized: "weekly.totalCountFormat"), total)
+    }
+
+    // MARK: - Private
+
+    private func bumpGeneration() -> Int {
+        generation += 1
+        return generation
+    }
+}
+
+// MARK: - WeeklySort localized
+
+extension WeeklySort {
+    var localizedTitle: String {
+        switch self {
+        case .firstIssueDesc:
+            return String(localized: "weekly.sort.latestIssue")
+        case .starsDesc:
+            return String(localized: "weekly.sort.starsDesc")
+        }
+    }
+}

--- a/Starcat/Resources/Localizable.xcstrings
+++ b/Starcat/Resources/Localizable.xcstrings
@@ -1462,6 +1462,261 @@
         }
       }
     },
+    "activity.category.weekly" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weekly"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "周刊"
+          }
+        }
+      }
+    },
+    "weekly.empty.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No weekly projects yet"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无周刊项目"
+          }
+        }
+      }
+    },
+    "weekly.empty.subtitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try refreshing or removing filters."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尝试刷新，或者放宽筛选条件。"
+          }
+        }
+      }
+    },
+    "weekly.filter.sort" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sort"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排序"
+          }
+        }
+      }
+    },
+    "weekly.filter.language" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Language"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语言"
+          }
+        }
+      }
+    },
+    "weekly.filter.allLanguages" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All languages"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部语言"
+          }
+        }
+      }
+    },
+    "weekly.sort.latestIssue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Latest issue"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最新收录"
+          }
+        }
+      }
+    },
+    "weekly.sort.starsDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Most stars"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stars 最多"
+          }
+        }
+      }
+    },
+    "weekly.refresh" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新"
+          }
+        }
+      }
+    },
+    "weekly.action.openRepo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open on GitHub"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 GitHub 打开"
+          }
+        }
+      }
+    },
+    "weekly.action.openIssue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open source issue"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开周刊原文"
+          }
+        }
+      }
+    },
+    "weekly.action.copyURL" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy URL"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制链接"
+          }
+        }
+      }
+    },
+    "weekly.action.retry" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重试"
+          }
+        }
+      }
+    },
+    "weekly.issueLabelFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Issue %d"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第 %d 期"
+          }
+        }
+      }
+    },
+    "weekly.totalCountFormat" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d projects"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共 %d 项"
+          }
+        }
+      }
+    },
     "activity.detail.assets" : {
       "localizations" : {
         "en" : {

--- a/StarcatTests/WeeklyDTOTests.swift
+++ b/StarcatTests/WeeklyDTOTests.swift
@@ -1,0 +1,132 @@
+//
+//  WeeklyDTOTests.swift
+//  StarcatTests
+//
+//  验证 WeeklyProjectListDTO / WeeklyProjectDTO 能正确解码 starcat-weekly-api
+//  约定的响应格式，并能转换成 UI 消费的 `WeeklyProject` 领域模型。
+//
+//  关键约束：
+//  - DTO 不开 `.convertFromSnakeCase`，所有 snake_case 字段都通过 CodingKeys 显式映射；
+//    本测试确保即便后端返回严格 snake_case，仍能正确解出 firstIssue / issueUrl。
+//  - description / language 可缺；缺字段时默认值要落到 UI 友好的回退值。
+//
+
+import Testing
+import Foundation
+@testable import Starcat
+
+@Suite("Weekly DTO 解码")
+struct WeeklyDTOTests {
+
+    private var decoder: JSONDecoder { JSONDecoder() }
+
+    @Test("完整响应解码到 WeeklyProject")
+    func decodeFullList() throws {
+        let json = #"""
+        {
+          "items": [
+            {
+              "owner": "alice",
+              "repo": "awesome-tool",
+              "url": "https://github.com/alice/awesome-tool",
+              "description": "An awesome tool",
+              "stars": 1234,
+              "language": "Go",
+              "first_issue": 399,
+              "issue_url": "https://github.com/ruanyf/weekly/blob/master/docs/issue-399.md"
+            }
+          ],
+          "total": 1,
+          "page": 1,
+          "page_size": 20
+        }
+        """#
+
+        let data = try #require(json.data(using: .utf8))
+        let dto = try decoder.decode(WeeklyProjectListDTO.self, from: data)
+
+        #expect(dto.items.count == 1)
+        #expect(dto.total == 1)
+        #expect(dto.page == 1)
+        #expect(dto.pageSize == 20)
+
+        let project = WeeklyProject(dto: dto.items[0])
+        #expect(project.owner == "alice")
+        #expect(project.name == "awesome-tool")
+        #expect(project.fullName == "alice/awesome-tool")
+        #expect(project.stars == 1234)
+        #expect(project.language == "Go")
+        #expect(project.firstIssue == 399)
+        #expect(project.url.absoluteString == "https://github.com/alice/awesome-tool")
+        #expect(project.issueURL?.absoluteString == "https://github.com/ruanyf/weekly/blob/master/docs/issue-399.md")
+    }
+
+    @Test("description / language / issue_url 缺失时使用回退")
+    func decodeWithMissingOptionalFields() throws {
+        let json = #"""
+        {
+          "items": [
+            {
+              "owner": "bob",
+              "repo": "tiny",
+              "url": "https://github.com/bob/tiny",
+              "stars": 0,
+              "first_issue": 0,
+              "issue_url": ""
+            }
+          ],
+          "total": 1,
+          "page": 1,
+          "page_size": 20
+        }
+        """#
+
+        let data = try #require(json.data(using: .utf8))
+        let dto = try decoder.decode(WeeklyProjectListDTO.self, from: data)
+        let project = WeeklyProject(dto: dto.items[0])
+
+        #expect(project.description == nil)
+        #expect(project.language == nil)
+        #expect(project.firstIssue == 0)
+        #expect(project.issueURL == nil, "issue_url 空串时不应该构造出 URL")
+    }
+
+    @Test("空 items 不报错")
+    func decodeEmptyList() throws {
+        let json = #"""
+        { "items": [], "total": 0, "page": 1, "page_size": 20 }
+        """#
+        let data = try #require(json.data(using: .utf8))
+        let dto = try decoder.decode(WeeklyProjectListDTO.self, from: data)
+        #expect(dto.items.isEmpty)
+        #expect(dto.total == 0)
+    }
+}
+
+@Suite("WeeklyProjectListResult.hasMore 推算")
+struct WeeklyProjectListResultTests {
+
+    @Test("还有下一页时 hasMore = true")
+    func hasMoreWhenPagesRemain() {
+        let result = WeeklyProjectListResult(items: [], total: 100, page: 1, pageSize: 20)
+        #expect(result.hasMore == true)
+    }
+
+    @Test("最后一页时 hasMore = false")
+    func noMoreOnLastPage() {
+        let result = WeeklyProjectListResult(items: [], total: 100, page: 5, pageSize: 20)
+        #expect(result.hasMore == false)
+    }
+
+    @Test("total 不足一页时 hasMore = false")
+    func noMoreWhenLessThanOnePage() {
+        let result = WeeklyProjectListResult(items: [], total: 5, page: 1, pageSize: 20)
+        #expect(result.hasMore == false)
+    }
+
+    @Test("pageSize 0 时 hasMore = false 兜底")
+    func noMoreWhenPageSizeZero() {
+        let result = WeeklyProjectListResult(items: [], total: 5, page: 1, pageSize: 0)
+        #expect(result.hasMore == false)
+    }
+}


### PR DESCRIPTION
## Summary

- Activity 页新增 **Weekly** 分类，接入阮一峰周刊 [ruanyf/weekly](https://github.com/ruanyf/weekly) 推荐的 GitHub 项目
- 数据源：独立 Go 后端服务 [starcat-weekly-api](https://github.com/dong4j/starcat-weekly-api)（默认 `https://starcat-weekly-api.fly.dev`）
- 关联任务：MUL-176

## 主要变更

- `Starcat/Core/Network/WeeklyAPI.swift`：actor + URLSession 客户端，与 `TrendingAPI` 同款风格
- `Starcat/Core/Network/WeeklyModels.swift`：DTO + `WeeklyProject` 领域模型 + `WeeklySort` / `WeeklyIssueFilter` 枚举
- `Starcat/Features/Activity/ActivityModels.swift`：`ActivityCategory` 新增 `weekly` case（Rust 米色色点 + `newspaper` 图标）
- `Starcat/Features/Activity/ActivityView.swift`：选中 `.weekly` 时整体切换到 `WeeklyContentView`，绕过 `ActivityViewModel` 的本地聚合
- `Starcat/Features/Activity/WeeklyContentView.swift`：独立的 View + ViewModel，含分页 / 排序 / 语言筛选 / 外链跳转 / context menu
- `Starcat/App/AppDependencies.swift`：注入 `weeklyAPI` 单例
- `Starcat/Resources/Localizable.xcstrings`：新增 14 个 `weekly.*` 键中英双语
- `StarcatTests/WeeklyDTOTests.swift`：4 个单测覆盖完整解码、缺字段回退、空列表、`hasMore` 推算

## 设计要点

1. **数据源隔离**：weekly 是远端分页 + 排序 + 多维筛选，不复用 `ActivityViewModel` 本地聚合逻辑，避免污染其"本地缓存事实源"语义
2. **代次（generation）机制**：切筛选 / 主动刷新时 bump，旧请求即便回来也被丢弃，防止顺序错乱
3. **无限滚动**：倒数第 3 行触发下一页加载，去重保险（同 id 不重复追加）
4. **外链跳转**：点击行直接 `NSWorkspace.shared.open(url)` 打开 GitHub，不进 `ActivityDetailView`（这些是远端项目，本地 Repo 缓存里没有，复用详情页会撞空误导用户）
5. **色点选择**：Rust 米色（`#dea584`），与已有 7 个分类色点都不撞，且与"周刊"的温和气质契合

## 验证

- `swiftc -parse` 各文件语法解析通过
- `xcodegen generate` 工程文件生成成功
- `python3 -c "import json; json.load(...)"` 校验 `Localizable.xcstrings` 仍是合法 JSON
- 本机未安装 Xcode，**完整 `xcodebuild` 验证需要 reviewer 在本地或 CI 跑一次**

## 测试计划

- [ ] `xcodebuild test -scheme Starcat` 跑通 `WeeklyDTOTests` 中 4 个用例
- [ ] 启动 App → Activity → 侧栏选择"周刊" → 列表加载出真实数据
- [ ] 切换排序 / 语言筛选 → 列表重置并重新拉取
- [ ] 滚动到底部 → 自动加载下一页
- [ ] 点击行 → 浏览器打开对应 GitHub 仓库
- [ ] Context menu → "打开周刊原文" 跳转 ruanyf/weekly 对应期 md
- [ ] 后端尚未部署时（默认域名不可用），UI 显示错误态 + 重试按钮可用

## 后端依赖

后端服务待部署到 `https://starcat-weekly-api.fly.dev`（dong4j 已确认会处理部署）。部署前可通过修改 `AppDependencies.weeklyAPI = WeeklyAPI(baseURL: URL(...))` 临时指向本地 `localhost:5001` 联调。

Closes MUL-176
