### PR TITLE
fix(starcat): 搜索历史改在打开时拉取，避开 anonymous DB 时序 (HOM-199)

### DIFF
--- a/Starcat/Features/Search/SearchCenterViewModel.swift
+++ b/Starcat/Features/Search/SearchCenterViewModel.swift
@@ -55,9 +55,19 @@ final class SearchCenterViewModel {
         self.historyRepository = historyRepository
         self.includeWebInAll = includeWebInAll
 
-        // 首次构造异步拉一次历史；调用方不需要 await，UI 出现后逐渐填充即可。
-        // 失败时静默置空（历史不可见好过把 UI 卡住）。
-        Task { await self.reloadHistory() }
+        // 历史加载放在 `present()` 触发，不在 init 做。
+        //
+        // HOM-199 修复（dong4j 2026-06-14）：原实现在 init 里 `Task { await reloadHistory() }`,
+        // 但 HomeView.init 与 AppDependencies.init 同步发生在 `_anonymous` 占位 DB 阶段
+        // （D-30 多账号 DB 隔离），此时 `historyRepository.fetchAll()` 命中的是空的占位库；
+        // 之后 `AuthSession.restoreSessionIfAvailable` → `database.reopen(userId:)` 把 DB
+        // pool 切到该 user 的真实 SQLite，但本 VM 没有任何路径再拉一次 → `history` 永远停留
+        // 在空快照，用户必须先 submit 一次才能间接触发 `reloadHistory()`（见 `submit()`）
+        // 把真实历史搬上来。
+        //
+        // 修法选型（dong4j 选择方案 2，与 AuthSession 解耦）：每次 `present()` 时按需 reload。
+        // 代价：首次打开会多一次 SQLite 读（50 行表，<1ms）；收益：彻底回避 DB 切换时序窗口，
+        // ViewModel 不需要订阅 AuthSession.state，分层依然干净。
     }
 
     var candidates: [SearchCandidate] {
@@ -151,6 +161,12 @@ final class SearchCenterViewModel {
         // 重新打开只恢复面板，不重置选中项或重新搜索。用户误点遮罩关闭后应回到
         // 原来的 query、scope、filters、结果和键盘位置。
         isPresented = true
+        // HOM-199 修复：每次打开都 fire-and-forget 拉一次最新历史。
+        // - 首次打开（init 后从未加载）→ 把历史从真实 user DB 填进来；
+        // - 后续打开 → 顺便吸收上一次提交可能并发产生的写入（成本：单次 50 行表 SQLite read）。
+        // 用 detached-on-MainActor 模式：本 VM 是 @MainActor，`Task { ... }` 继承 actor，
+        // SwiftUI Button 调用 present() 时不需要 await，UI 已经显示后历史会异步填充。
+        Task { await self.reloadHistory() }
     }
 
     func dismiss() {


### PR DESCRIPTION
## Summary

- D-30 多账号 DB 隔离后，`SearchCenterViewModel.init` 在 `_anonymous` DB 期间触发 `reloadHistory()`，拿到的总是空快照
- `AuthSession.restoreSessionIfAvailable` 把 DB 切到真实用户 pool 时，本 VM 没有任何路径再拉一次 → history 永远停留在 init 时的空列表
- 把 `reloadHistory()` 从 `init` 移到 `present()`，每次打开搜索面板都 fire-and-forget 拉一次最新历史

## Test plan

- [ ] 全新登录后，立即按 ⌘F 打开搜索面板：能看到之前生成的搜索历史
- [ ] 切账号后打开搜索面板：看到新账号自己的历史而不是空 / 老账号的
- [ ] 同一登录态下反复打开搜索面板：每次都展示最新历史（提交一条搜索后再次打开，新条目出现在顶部）

相关 issue: [HOM-199](mention://issue/96457a3b-48f4-4341-889f-42331d62b5b7)

Made with [Cursor](https://cursor.com)