### PR TITLE
fix(starcat): DB 切换后立即 reload StarredRegistry，不再等 SyncManager (HOM-199)

### DIFF
--- a/Starcat/App/AppDependencies.swift
+++ b/Starcat/App/AppDependencies.swift
@@ -548,6 +548,21 @@ final class AppDependencies {
                     "switchUserDatabase failed for userId=\(userId.map(String.init) ?? "anonymous", privacy: .public): \(error.localizedDescription, privacy: .public)"
                 )
             }
+
+            // HOM-199 B1：DB 切到新用户后立即 reload StarredRegistry。
+            //
+            // 为什么不依赖 `onSyncCompleted`：那是 SyncManager.performFullSync 跑完才触发，
+            // 通常滞后 1~5 秒。这段窗口里所有 RepoCardViewData.isStarred 都从空 / 旧用户的
+            // registry 读出 → 卡片心形全空、HomeViewModel 的 isStarred 投影错误，
+            // 直到 sync 完成才"突然出现"心形，体验割裂。
+            //
+            // 这里 reload 的是 **登录前已经持久化在用户 DB 里的** repos.is_starred 列，
+            // 不需要走网络——纯磁盘读 < 50ms，可以接受同步等待。
+            //
+            // signOut 路径（userId == nil）也跑：DB 已切到 _anonymous，registry 应是空集；
+            // 走 reload 会从 anonymous DB 读到空集，等价 `clearOnSignOut()`，不冲突。
+            // 失败容忍：reload 内部已 try/catch + 日志，不会向外抛错破坏 closure 语义。
+            await self.starredRegistryBootstrapper.reload()
         }
 
         // 启动期 reload：异步 Task，不阻塞 init。测试 host 跳过避免触发 DB 启动期成本。


### PR DESCRIPTION
## Summary

- `AuthSession.onUserSessionChanged` → `AppDependencies.switchUserDatabase` 切 SQLite pool 后，`StarredRegistry`（in-memory `Set<Int64>`）只在 `SyncManager.onSyncCompleted` 时 reload，`performFullSync` 通常滞后 1~5 秒
- 这段窗口里所有 `RepoCardViewData.isStarred` / `HomeViewModel` 投影从空（启动时刚装配）或上一账户的 registry 读出 → 卡片心形全空，直到 sync 完成才"突然出现"，体验割裂
- 在 `onUserSessionChanged` closure 末尾追加 `await self.starredRegistryBootstrapper.reload()`：DB 切完立即从 `repos.is_starred` 列重读快照，纯磁盘读 < 50ms

## 路径安全性

- **登录路径**：DB 已切到用户 DB → reload 拿到 `is_starred = 1` 快照，UI 心形立即正确
- **登出路径**（`userId == nil`）：DB 已切 `_anonymous`（空库）→ reload 等价于 `clearOnSignOut()`，不冲突
- reload 内部已 try/catch + 日志，失败不破坏 closure 语义
- SyncManager 完成后仍会再 reload 一次，覆盖云端最新差异

## Test plan

- [ ] 冷启动登录已有账号：进入主界面瞬间所有 star 仓库心形正确，无需等待
- [ ] 注销 → 登录另一账号：心形快速切换到新账号的星标集合
- [ ] 离线情况下登录（DB 命中但 SyncManager 失败）：仍能看到本地持久化的 star 状态

相关 issue: [HOM-199](mention://issue/96457a3b-48f4-4341-889f-42331d62b5b7)

Made with [Cursor](https://cursor.com)