### PR TITLE
fix(starcat): AI 摘要缓存 hash 剔除流量字段，避免 sync 后失效 (HOM-199)

### DIFF
--- a/Starcat/Features/AI/RepoAIInsightService.swift
+++ b/Starcat/Features/AI/RepoAIInsightService.swift
@@ -455,7 +455,32 @@ final class RepoAIInsightService {
             }
             return ""
         }()
-        var source = [
+
+        // HOM-199 AI 摘要缓存稳定化（2026-06-14）：拆分"喂 LLM 的文本"和"缓存键 hash"两条路径。
+        //
+        // 旧版用同一个 `source` 字符串既送 LLM 又算 SHA256 写进 `ai_summaries.source_hash`。
+        // 但 `source` 里塞了 `Stars: N` / `Forks: M` 这种 GitHub sync 每次都会刷新的流量数据，
+        // 导致——
+        //   1. 用户登录 / 重新登录 → AuthSession 触发立即 performFullSync；
+        //   2. 几乎每个仓库的 starsCount / forksCount 都被刷成新值；
+        //   3. 所有 ai_summaries.source_hash 一次性全部失效；
+        //   4. UI 端 cachedInsight() 因 hash 不匹配返回 nil → 用户看到"AI 摘要全部消失"，
+        //      数据其实没丢，DB 表里 summary_json 还在。
+        //
+        // 修复策略：保留 `llmText`（含 stars/forks/homepage，让 LLM 仍有热度感知，
+        // 重新生成时摘要质量不退化），但 `hashText` 只包含"语义稳定子集"：
+        //   - repo 身份：fullName
+        //   - 作者主动维护的元信息：description / language / topics / license
+        //   - README 正文
+        //   - 代码上下文 XML（commit SHA 改 = 代码语义改，应该重生成 → 仍进 hash）
+        //
+        // 剔除字段：
+        //   - Stars / Forks：纯流量数据，不影响"这个项目做什么"的判定
+        //   - Homepage：少数仓库主会改，但改了不需要重生成摘要（首页 URL 跟项目定位无关）
+        //
+        // 注：旧 hash 与新 hash 算法不同，存量缓存会一次性"看似失效"。这是一次性升级代价；
+        // 之后该 repo 重新生成一次即可永久稳定，不会再因为 stars 涨一颗就失效。
+        var llmText = [
             "Repository: \(repo.fullName)",
             "Description: \(repo.description ?? "")",
             "Language: \(repo.language ?? "")",
@@ -464,6 +489,16 @@ final class RepoAIInsightService {
             "Stars: \(repo.starsCount)",
             "Forks: \(repo.forksCount)",
             "Homepage: \(repo.homepage ?? "")",
+            "README:",
+            readmeText
+        ].joined(separator: "\n")
+
+        var hashText = [
+            "Repository: \(repo.fullName)",
+            "Description: \(repo.description ?? "")",
+            "Language: \(repo.language ?? "")",
+            "Topics: \(repo.topics ?? "")",
+            "License: \(repo.license ?? "")",
             "README:",
             readmeText
         ].joined(separator: "\n")
@@ -490,7 +525,10 @@ final class RepoAIInsightService {
             case .success(let result):
                 if let contextXml = try? String(contentsOf: result.url, encoding: .utf8),
                    !contextXml.isEmpty {
-                    source += "\n\n" + contextXml
+                    // 代码上下文 XML 既给 LLM 用又进 hash：commit SHA 改 = 代码语义改
+                    // = 该重生成摘要。这是"语义级变更"，不属于 HOM-199 要稳定化的流量字段。
+                    llmText += "\n\n" + contextXml
+                    hashText += "\n\n" + contextXml
                     contextMeta = RepoAIInsightContextMeta(
                         commitSha: result.metadata.commitSha,
                         ref: result.metadata.ref,
@@ -510,8 +548,8 @@ final class RepoAIInsightService {
         }
 
         return Source(
-            text: source,
-            hash: Self.hash(source),
+            text: llmText,
+            hash: Self.hash(hashText),
             contextMeta: contextMeta,
             contextDegradationReason: degradationReason
         )


### PR DESCRIPTION
## 问题

`RepoAIInsightService.cachedInsight()` 用 `source.hash` 判定 `ai_summaries` 缓存是否仍可复用。旧版 `makeSource()` 把 `Stars` / `Forks` / `Homepage` 都拼进同一个 `source` 字符串，既送 LLM 又算 SHA256 写进 `ai_summaries.source_hash`。

但 stars/forks **每次 GitHub sync 都会刷新**。用户登录 / 重新登录会立即触发 `performFullSync` →
1. 几乎每个仓库的 starsCount / forksCount 都被刷成新值
2. 所有 `ai_summaries.source_hash` 一次性集体失效
3. UI 端 `cachedInsight()` 因 hash 不匹配返回 nil
4. 用户看到「AI 摘要全部消失」

DB 表里 `summary_json` 其实没丢，只是判等失败。重新生成会白白吃一次 token。

## 修复

拆分两条路径：

| | 内容 | 用途 |
|---|---|---|
| `llmText` | repo 身份 + description / language / topics / license + **stars / forks / homepage** + README + 代码上下文 XML | 送 LLM 生成摘要 |
| `hashText` | repo 身份 + description / language / topics / license + README + 代码上下文 XML | 算 SHA256 写进 `source_hash` |

剔除字段（仅从 hash 剔除，LLM 仍能看到）：
- **Stars / Forks**：纯流量数据，不影响"这个项目做什么"的判定
- **Homepage**：少数仓库主会改，但改了不需要重生成摘要（首页 URL 跟项目定位无关）

代码上下文 XML 仍同时进 `llmText` 和 `hashText`：commit SHA 变化 = 代码语义改，属于"该重生成"的语义级变更，不在本次稳定化范围内。

## 升级一次性影响

算法变更后存量 `ai_summaries` 看似全部失效（旧 hash ≠ 新 hash）。用户每个 repo 需要**重新生成一次**，之后永久稳定，不会再因 stars 涨一颗失效。

这是一次性代价，且本来当前 bug 状态下 stars 一刷新就要重生成；修复后只有真正语义变更才会重生成。

## Test plan

- [ ] 已生成过 AI 摘要的 repo，注销 → 重新登录 → 重新打开 AI 窗口：摘要立即展示（旧版会因 sync 改了 stars 而判定失效）
- [ ] 同一登录态下 SyncManager 增量 sync 后再开 AI 窗口：摘要保持可见
- [ ] 仓库作者改了 description / topics / license：重新打开 AI 窗口提示重生成（这是预期行为，语义变了）
- [ ] 代码上下文开关打开时，仓库有新 commit：重新打开 AI 窗口提示重生成（语义变了）
- [ ] 升级前已生成过摘要的 repo：首次打开会因 hash 算法变化重生成一次，之后稳定

相关 issue: [HOM-199](mention://issue/96457a3b-48f4-4341-889f-42331d62b5b7)

Made with [Cursor](https://cursor.com)