### PR TITLE
perf(starcat): AI 代码上下文设置页性能优化 (HOM-203)

### DIFF
--- a/Starcat/Features/AI/RepoAIContextProvider.swift
+++ b/Starcat/Features/AI/RepoAIContextProvider.swift
@@ -280,7 +280,8 @@ struct RepoAIContextProvider {
         output: PackOutput,
         tokenEstimatorVersion: String
     ) -> PackMetadata {
-        let isoNow = ISO8601DateFormatter.starcatPackerFormatter.string(from: .now)
+        // HOM-203：metadata 字段已是 Date 类型，直接传 .now 即可。
+        let now = Date()
         return PackMetadata(
             schemaVersion: 1,
             tierRulesVersion: TierRules.tierRulesVersion,
@@ -289,13 +290,13 @@ struct RepoAIContextProvider {
             repo: input.repo,
             ref: input.ref,
             commitSha: input.commitSha,
-            generatedAt: isoNow,
+            generatedAt: now,
             tokenBudget: input.tokenBudget,
             stats: output.stats,
             skippedFiles: [],
             warnings: ["metadataReadFallback"],
             tier1MaxLines: input.tier1MaxLines,
-            lastAccessedAt: isoNow,
+            lastAccessedAt: now,
             generationCount: 1
         )
     }

--- a/Starcat/Features/CodeGraph/CodeFlowStorage.swift
+++ b/Starcat/Features/CodeGraph/CodeFlowStorage.swift
@@ -101,6 +101,43 @@ struct CodeFlowStoredProject: Identifiable, Equatable, Sendable {
     }
 }
 
+/// HOM-203：CodeFlow 产物根目录的汇总缓存（落盘为 `<root>/.starcat-summary.json`）。
+///
+/// 与 `RepoContextSummary` 同款设计——UI 渲染 4 列汇总用，per-project metadata.json
+/// 仍是真源。CodeFlow 项目数通常远少于 RepoContext，但保持对称便于 UI 复用且
+/// 防止集成 Tab 同样进入 O(n) 扫描卡顿。
+struct CodeFlowSummary: Codable, Sendable, Equatable {
+    let schemaVersion: Int
+    let projectCount: Int
+    let totalBytes: Int64
+    let totalGenerationCount: Int
+    let latestGeneratedAt: Date?
+    let updatedAt: Date
+
+    static let currentSchemaVersion: Int = 1
+    static let filename: String = ".starcat-summary.json"
+
+    static let empty: CodeFlowSummary = .init(
+        schemaVersion: currentSchemaVersion,
+        projectCount: 0,
+        totalBytes: 0,
+        totalGenerationCount: 0,
+        latestGeneratedAt: nil,
+        updatedAt: .distantPast
+    )
+
+    func withUpdatedAt(_ date: Date) -> CodeFlowSummary {
+        .init(
+            schemaVersion: schemaVersion,
+            projectCount: projectCount,
+            totalBytes: totalBytes,
+            totalGenerationCount: totalGenerationCount,
+            latestGeneratedAt: latestGeneratedAt,
+            updatedAt: date
+        )
+    }
+}
+
 enum CodeFlowStorageError: LocalizedError {
     case outputDirectoryUnavailable
     case invalidBookmark
@@ -132,7 +169,9 @@ final class CodeFlowStorage {
     private let defaults: UserDefaults
     private let fixedRootURL: URL?
 
-    private(set) var projects: [CodeFlowStoredProject] = []
+    /// HOM-203：UI 渲染唯一来源（与 `RepoContextStorage.summary` 对称）。
+    /// nil 表示尚未加载，首次进入设置页时由 `reload()` 触发加载。
+    private(set) var summary: CodeFlowSummary?
     private(set) var lastErrorMessage: String?
     private var directoryConfigurationRevision: Int = 0
 
@@ -156,15 +195,13 @@ final class CodeFlowStorage {
         return (try? resolveOutputRoot().url.path) ?? String.l10n("storage.outputDirectory.bookmarkExpired")
     }
 
-    var totalBytes: Int64 { projects.reduce(0) { $0 + $1.totalBytes } }
+    var totalBytes: Int64 { summary?.totalBytes ?? 0 }
 
-    var totalGenerationCount: Int {
-        projects.reduce(0) { $0 + $1.metadata.generation.generationCount }
-    }
+    var totalGenerationCount: Int { summary?.totalGenerationCount ?? 0 }
 
-    var latestGeneratedAt: Date? {
-        projects.map(\.metadata.generation.generatedAt).max()
-    }
+    var latestGeneratedAt: Date? { summary?.latestGeneratedAt }
+
+    var projectCount: Int { summary?.projectCount ?? 0 }
 
     /// 保存用户通过 NSOpenPanel 主动选择的目录，并把当前 CodeFlow 项目迁移过去。
     ///
@@ -214,14 +251,30 @@ final class CodeFlowStorage {
         reload()
     }
 
+    /// HOM-203：与 RepoContextStorage 同款 summary 优先策略。
+    /// summary 文件存在 + schemaVersion 匹配 + 一级目录数偏差 ≤ 阈值 → O(1) 命中；
+    /// 否则降级 `rebuildSummaryOnDisk`（O(n) 扫子目录 + 重写 summary）。
     func reload() {
         do {
-            projects = try withOutputRoot { root in
-                try scanProjects(root: root)
+            try withOutputRoot { root in
+                try loadOrRebuildSummary(root: root)
             }
             lastErrorMessage = nil
         } catch {
-            projects = []
+            summary = .empty
+            lastErrorMessage = error.localizedDescription
+        }
+    }
+
+    /// 强制完整重扫 + 重写 summary。手工调试 / 故障排查用，业务路径走 `reload()`。
+    func rebuildSummary() {
+        do {
+            try withOutputRoot { root in
+                try rebuildSummaryOnDisk(root: root)
+            }
+            lastErrorMessage = nil
+        } catch {
+            summary = .empty
             lastErrorMessage = error.localizedDescription
         }
     }
@@ -235,20 +288,21 @@ final class CodeFlowStorage {
     func write(pageHTML: String, metadata: CodeFlowMetadata, owner: String, name: String) throws -> CodeFlowStoredProject {
         try withOutputRoot { root in
             let directory = projectDirectory(root: root, owner: owner, name: name)
+            // HOM-203：写入前先取旧项目快照（如果有），用于 summary 增量推算。
+            let existing = try? loadProject(directory: directory)
             try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
 
             let pageURL = directory.appendingPathComponent("index.html")
             let metadataURL = directory.appendingPathComponent("metadata.json")
             try pageHTML.write(to: pageURL, atomically: true, encoding: .utf8)
 
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            encoder.dateEncodingStrategy = .iso8601
+            let encoder = Self.metadataEncoder
             try encoder.encode(metadata).write(to: metadataURL, options: .atomic)
 
             guard let project = try loadProject(directory: directory) else {
                 throw CocoaError(.fileReadCorruptFile)
             }
+            updateSummaryAfterWrite(root: root, newProject: project, oldProject: existing)
             return project
         }
     }
@@ -257,13 +311,13 @@ final class CodeFlowStorage {
         try withOutputRoot { root in
             let directory = projectDirectory(root: root, owner: owner, name: name)
             let metadataURL = directory.appendingPathComponent("metadata.json")
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            encoder.dateEncodingStrategy = .iso8601
+            let existing = try? loadProject(directory: directory)
+            let encoder = Self.metadataEncoder
             try encoder.encode(metadata).write(to: metadataURL, options: .atomic)
             guard let project = try loadProject(directory: directory) else {
                 throw CocoaError(.fileReadCorruptFile)
             }
+            updateSummaryAfterWrite(root: root, newProject: project, oldProject: existing)
             return project
         }
     }
@@ -271,11 +325,12 @@ final class CodeFlowStorage {
     func deleteProject(owner: String, name: String) throws {
         try withOutputRoot { root in
             let directory = projectDirectory(root: root, owner: owner, name: name)
+            let removed = try? loadProject(directory: directory)
             if fileManager.fileExists(atPath: directory.path) {
                 try fileManager.removeItem(at: directory)
             }
+            updateSummaryAfterDelete(root: root, removed: removed)
         }
-        reload()
     }
 
     /// 只删除项目子目录，保留用户主动选择的输出根目录本身。
@@ -291,9 +346,18 @@ final class CodeFlowStorage {
                     try? fileManager.removeItem(at: ownerDirectory)
                 }
             }
+            writeSummary(.empty.withUpdatedAt(.now), root: root)
+            summary = .empty.withUpdatedAt(.now)
         }
-        reload()
     }
+
+    /// 共享的 metadata encoder（与 `loadProject` decoder 对称）。
+    private static let metadataEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
 
     func outputRootURL() throws -> URL {
         try resolveOutputRoot().url
@@ -313,6 +377,159 @@ final class CodeFlowStorage {
             try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
             NSWorkspace.shared.open(root)
         }
+    }
+
+    // MARK: - Summary 缓存（HOM-203）
+
+    /// 与 `RepoContextStorage.loadOrRebuildSummary` 同款策略：summary 命中走 O(1)，
+    /// 否则降级 rebuild。
+    private func loadOrRebuildSummary(root: URL) throws {
+        guard fileManager.fileExists(atPath: root.path) else {
+            try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+            let empty = CodeFlowSummary.empty.withUpdatedAt(.now)
+            writeSummary(empty, root: root)
+            summary = empty
+            return
+        }
+        if let cached = readSummary(root: root) {
+            if cached.schemaVersion != CodeFlowSummary.currentSchemaVersion {
+                try rebuildSummaryOnDisk(root: root)
+                return
+            }
+            let approximate = try approximateProjectCount(root: root)
+            let drift = abs(approximate - cached.projectCount)
+            let tolerance = max(10, cached.projectCount / 10)
+            if drift <= tolerance {
+                summary = cached
+                return
+            }
+        }
+        try rebuildSummaryOnDisk(root: root)
+    }
+
+    private func rebuildSummaryOnDisk(root: URL) throws {
+        let scanned = try scanProjects(root: root)
+        let computed = CodeFlowSummary(
+            schemaVersion: CodeFlowSummary.currentSchemaVersion,
+            projectCount: scanned.count,
+            totalBytes: scanned.reduce(0) { $0 + $1.totalBytes },
+            totalGenerationCount: scanned.reduce(0) { $0 + $1.metadata.generation.generationCount },
+            latestGeneratedAt: scanned.map(\.metadata.generation.generatedAt).max(),
+            updatedAt: .now
+        )
+        writeSummary(computed, root: root)
+        summary = computed
+    }
+
+    /// 与 RepoContext 同款：summary 缺失时退化到全量重建（重建结果包含本次写入）。
+    private func updateSummaryAfterWrite(
+        root: URL,
+        newProject: CodeFlowStoredProject,
+        oldProject: CodeFlowStoredProject?
+    ) {
+        guard let base = summary ?? readSummary(root: root) else {
+            try? rebuildSummaryOnDisk(root: root)
+            return
+        }
+        let projectCount = base.projectCount + (oldProject == nil ? 1 : 0)
+        let totalBytes = base.totalBytes + (newProject.totalBytes - (oldProject?.totalBytes ?? 0))
+        // CodeFlow 的 generationCount 语义：单个项目的累计生成次数，整体汇总按
+        // 各项目当前 generationCount 求和。重 pack（已有项目）总和增量是
+        // `new - old`；新建则是 `+ new`。
+        let countDelta = newProject.metadata.generation.generationCount
+            - (oldProject?.metadata.generation.generationCount ?? 0)
+        let totalGenerationCount = max(0, base.totalGenerationCount + countDelta)
+        let latestGeneratedAt: Date? = {
+            let candidate = newProject.metadata.generation.generatedAt
+            if let existing = base.latestGeneratedAt {
+                return max(existing, candidate)
+            }
+            return candidate
+        }()
+        let updated = CodeFlowSummary(
+            schemaVersion: CodeFlowSummary.currentSchemaVersion,
+            projectCount: projectCount,
+            totalBytes: totalBytes,
+            totalGenerationCount: totalGenerationCount,
+            latestGeneratedAt: latestGeneratedAt,
+            updatedAt: .now
+        )
+        writeSummary(updated, root: root)
+        summary = updated
+    }
+
+    private func updateSummaryAfterDelete(
+        root: URL,
+        removed: CodeFlowStoredProject?
+    ) {
+        guard let removed else {
+            summary = (summary ?? .empty).withUpdatedAt(.now)
+            return
+        }
+        guard let base = summary ?? readSummary(root: root) else {
+            try? rebuildSummaryOnDisk(root: root)
+            return
+        }
+        let nextCount = max(0, base.projectCount - 1)
+        let nextBytes = max(0, base.totalBytes - removed.totalBytes)
+        let nextGen = max(0, base.totalGenerationCount - removed.metadata.generation.generationCount)
+        let nextLatest: Date? = {
+            if nextCount == 0 { return nil }
+            return base.latestGeneratedAt
+        }()
+        let updated = CodeFlowSummary(
+            schemaVersion: CodeFlowSummary.currentSchemaVersion,
+            projectCount: nextCount,
+            totalBytes: nextBytes,
+            totalGenerationCount: nextGen,
+            latestGeneratedAt: nextLatest,
+            updatedAt: .now
+        )
+        writeSummary(updated, root: root)
+        summary = updated
+    }
+
+    private func readSummary(root: URL) -> CodeFlowSummary? {
+        let url = root.appendingPathComponent(CodeFlowSummary.filename, isDirectory: false)
+        guard fileManager.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(CodeFlowSummary.self, from: data)
+    }
+
+    private func writeSummary(_ summary: CodeFlowSummary, root: URL) {
+        let url = root.appendingPathComponent(CodeFlowSummary.filename, isDirectory: false)
+        do {
+            let data = try Self.metadataEncoder.encode(summary)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            // best-effort：缓存写失败不应阻止真源（per-project metadata.json）。
+            // CodeFlow 没有专用 logger，落到 stderr。
+            FileHandle.standardError.write(Data("[CodeFlowStorage] summary write failed: \(error.localizedDescription)\n".utf8))
+        }
+    }
+
+    private func approximateProjectCount(root: URL) throws -> Int {
+        let owners = try fileManager.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        var count = 0
+        for owner in owners where (try? owner.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
+            let repos = try fileManager.contentsOfDirectory(
+                at: owner,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+            count += repos.filter {
+                (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+            }.count
+        }
+        return count
     }
 
     private func withOutputRoot<T>(_ operation: (URL) throws -> T) throws -> T {
@@ -396,6 +613,9 @@ final class CodeFlowStorage {
                         try? fileManager.removeItem(at: ownerDirectory)
                     }
                 }
+                // HOM-203：源端 summary 也清掉，避免下次切回时被旧缓存误导。
+                let sourceSummary = sourceRoot.appendingPathComponent(CodeFlowSummary.filename, isDirectory: false)
+                try? fileManager.removeItem(at: sourceSummary)
             }
         }
     }

--- a/Starcat/Features/Settings/AISettingsView.swift
+++ b/Starcat/Features/Settings/AISettingsView.swift
@@ -1391,12 +1391,22 @@ struct AISettingsTab: View {
 
     /// Tier 1 关键文件保留行数 Stepper 行。范围 40-200、步进 20。
     /// 单 Stepper 占一行（与 aiIndexSection 的 ratioRow 同样的「标题 + 读数 + 控件」横向布局）。
+    ///
+    /// HOM-203：右侧读数原本写成 `Text("ai.context...Format \(value)")`，被 SwiftUI
+    /// 编译成 LocalizedStringKey `"ai.context...Format %@"`，xcstrings 中该带 `%@`
+    /// 的 entry 是空壳，运行时找不到翻译就回退成"显示 key 字面量"，于是用户看到
+    /// `ai.context.settings.tier1MaxLinesValueFormat 100` 这种纯 key。改成显式
+    /// `String.l10n + String(format:)`，与本视图其它行（如 line 1480 的统计 cell）
+    /// 风格保持一致；翻译模板里把 `%lld` 当行数占位符使用。
     private var repoContextTier1MaxLinesRow: some View {
         HStack {
             Text("ai.context.settings.tier1MaxLines")
                 .font(.callout)
             Spacer()
-            Text("ai.context.settings.tier1MaxLinesValueFormat \(settings.aiRepoContextTier1MaxLines)")
+            Text(String(
+                format: String.l10n("ai.context.settings.tier1MaxLinesValueFormat"),
+                settings.aiRepoContextTier1MaxLines
+            ))
                 .font(.callout.monospacedDigit())
                 .foregroundStyle(.secondary)
                 .frame(width: 60, alignment: .trailing)
@@ -1411,23 +1421,24 @@ struct AISettingsTab: View {
         }
     }
 
-    // MARK: - AI 代码上下文产物管理面板（HOM-68 v3 / 2026-06-15）
+    // MARK: - AI 代码上下文产物管理面板（HOM-68 v3 / 2026-06-15；HOM-203 性能改造）
     //
     // 历史背景：原方案只在 AI 设置里放一个「管理已生成的上下文 →」跳转按钮，把完整
     // 的输出目录 / 项目列表 / 单项删除面板放在 存储 Tab。dong4j 拍板把"精细化操作"
     // 集中到对应功能 Tab、把"全局汇总 + 一键清除"集中到 存储 Tab，因此本面板从
     // 存储 Tab 搬过来；存储 Tab 那边只保留汇总数字 + 行内"清理"按钮。
     //
+    // **HOM-203（2026-06-16）改造**：用户反馈 576 个 repo 时本面板的 ForEach 渲染
+    // 让设置页明显卡顿；同时 per-repo "打开 / 删除" 已被存储 Tab 的"全部清除"覆盖。
+    // 决议：移除 ForEach + 单项 "打开 / 删除" 按钮；汇总统计源切到 `summary` 缓存
+    // （`.starcat-summary.json`），UI 一次磁盘读取拿到 4 个数字，不再 O(n) 解析
+    // metadata.json。详见 `RepoContextStorage` 的 HOM-203 注释。
+    //
     // 视觉对照 `IntegrationSettingsView.codeFlowSection`，保持两类产物（CodeFlow /
     // RepoContextPacker）的 UI 节奏一致：
     //   1. 输出目录路径行 + 「选择目录 / 在 Finder 显示 / 重置默认」3 个按钮；
     //   2. 4 列汇总统计（项目数 / 占用 / 累计生成 / 最后生成）；
-    //   3. 错误状态 / 空状态 / 项目列表三态切换；
-    //   4. 项目列表中每行：仓库名 + 元信息 caption + 「打开 / 删除」按钮。
-    //
-    // 与 CodeFlow 的差异：
-    //   - **不提供"预览"按钮**：context.xml 不是给用户直接看的，没有"预览页面"概念。
-    //   - **不提供"一键清除"按钮**：搬到 存储 Tab 作为汇总入口；本地仅保留单项删除。
+    //   3. 错误状态 / 空状态 提示。
 
     /// AI 代码上下文产物管理面板。
     @ViewBuilder
@@ -1473,7 +1484,7 @@ struct AISettingsTab: View {
 
             HStack(spacing: 18) {
                 aiContextStat(titleKey: "ai.context.storage.statRepos",
-                              value: "\(aiContextStorage.projects.count)")
+                              value: "\(aiContextStorage.projectCount)")
                 aiContextStat(titleKey: "ai.context.storage.statBytes",
                               value: ByteCountFormatter.string(fromByteCount: aiContextStorage.totalBytes, countStyle: .file))
                 aiContextStat(titleKey: "ai.context.storage.statGenerations",
@@ -1493,14 +1504,10 @@ struct AISettingsTab: View {
                 Label(message, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.red)
-            } else if aiContextStorage.projects.isEmpty {
+            } else if aiContextStorage.projectCount == 0 {
                 Text("ai.context.storage.empty")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-            } else {
-                ForEach(aiContextStorage.projects) { project in
-                    aiContextProjectRow(project)
-                }
             }
         }
         .disabled(!settings.aiRepoContextEnabled)
@@ -1512,37 +1519,6 @@ struct AISettingsTab: View {
         VStack(alignment: .leading, spacing: 2) {
             Text(titleKey).font(.caption2).foregroundStyle(.secondary)
             Text(value).font(.caption.weight(.medium))
-        }
-    }
-
-    /// 单个产物行（一个 `<owner>/<repo>` 项目）。绑定 `RepoContextStoredProject`。
-    /// 与 CodeFlow projectRow 不同点：① 不提供"预览"按钮；② 不显示"详情" disclosure
-    /// （context.xml metadata 不需要让用户深扒）。
-    private func aiContextProjectRow(_ project: RepoContextStoredProject) -> some View {
-        let metadata = project.metadata
-        let commitShortSHA = String(metadata.commitSha.prefix(7))
-        let xmlBytesStr = ByteCountFormatter.string(fromByteCount: Int64(metadata.stats.contextXmlBytes), countStyle: .file)
-        let actualTokens = metadata.stats.actualTokens
-        let totalFiles = metadata.stats.totalFiles
-        return HStack(spacing: 10) {
-            VStack(alignment: .leading, spacing: 3) {
-                Text("\(metadata.owner)/\(metadata.repo)")
-                    .font(.callout.weight(.medium))
-                Text("\(metadata.ref) · \(commitShortSHA) · XML \(xmlBytesStr) · \(actualTokens) tokens · \(totalFiles) files")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                Text(project.generatedAtDate.formatted(date: .abbreviated, time: .shortened))
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer()
-            Button("ai.context.storage.menuReveal") {
-                revealAIContextProject(project)
-            }
-            Button("ai.context.storage.menuDelete", role: .destructive) {
-                deleteAIContextProject(project)
-            }
         }
     }
 
@@ -1581,21 +1557,9 @@ struct AISettingsTab: View {
         }
     }
 
-    private func revealAIContextProject(_ project: RepoContextStoredProject) {
-        do {
-            try aiContextStorage.revealProject(project)
-        } catch {
-            aiContextActionError = error.localizedDescription
-        }
-    }
-
-    private func deleteAIContextProject(_ project: RepoContextStoredProject) {
-        do {
-            try aiContextStorage.deleteProject(owner: project.metadata.owner, repo: project.metadata.repo)
-        } catch {
-            aiContextActionError = error.localizedDescription
-        }
-    }
+    // HOM-203：单项 reveal / delete 已经移除——repo 列表整体砍掉，"全部清除"
+    // 在 设置 → 存储 Tab 已有入口，不再需要单项操作。`storage.revealProject`
+    // 和 `storage.deleteProject` API 仍保留供未来使用 / 单测。
 
     /// Token 预算 Int↔Double 适配 binding。
     /// SwiftUI Slider 要求 `BinaryFloatingPoint` 值类型，但 `aiRepoContextTokenBudget` 是 Int

--- a/Starcat/Features/Settings/IntegrationSettingsView.swift
+++ b/Starcat/Features/Settings/IntegrationSettingsView.swift
@@ -20,6 +20,10 @@ struct IntegrationSettingsTab: View {
     // HOM-68 v3 (2026-06-15)：CodeFlow"一键清除"按钮搬到 存储 Tab → 缓存用量。
     // 本 Tab 仅保留"精细化操作"（输出目录配置、单项目预览/打开/删除）。
     // → 与 AISettingsView.repoContextManageStorageRow 同款职责划分。
+    //
+    // HOM-203（2026-06-16）：与 AISettingsView 同款改造，移除项目明细列表 +
+    // per-project 预览/打开/删除按钮——大数据量下 ForEach 渲染会卡顿，且"全部
+    // 清除"在存储 Tab 已有入口。汇总 4 项数据切到 `summary` 缓存。
 
     var body: some View {
         Form {
@@ -62,7 +66,7 @@ struct IntegrationSettingsTab: View {
                 }
 
                 HStack(spacing: 18) {
-                    stat(titleKey: "settings.integration.codeFlow.stat.projects", value: "\(storage.projects.count)")
+                    stat(titleKey: "settings.integration.codeFlow.stat.projects", value: "\(storage.projectCount)")
                     stat(titleKey: "settings.integration.codeFlow.stat.usage", value: ByteCountFormatter.string(fromByteCount: storage.totalBytes, countStyle: .file))
                     stat(
                         titleKey: "settings.integration.codeFlow.stat.totalGenerated",
@@ -78,14 +82,10 @@ struct IntegrationSettingsTab: View {
                     Label(message, systemImage: "exclamationmark.triangle.fill")
                         .font(.caption)
                         .foregroundStyle(.red)
-                } else if storage.projects.isEmpty {
+                } else if storage.projectCount == 0 {
                     Text("settings.integration.codeFlow.empty")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                } else {
-                    ForEach(storage.projects) { project in
-                        projectRow(project)
-                    }
                 }
             }
         }
@@ -232,52 +232,10 @@ struct IntegrationSettingsTab: View {
         }
     }
 
-    private func projectRow(_ project: CodeFlowStoredProject) -> some View {
-        VStack(alignment: .leading, spacing: 7) {
-            HStack(spacing: 10) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(project.metadata.repository.fullName)
-                        .font(.callout.weight(.medium))
-                    Text("\(project.metadata.sourceRevision.branch) · \(project.metadata.sourceRevision.shortSHA) · HTML \(ByteCountFormatter.string(fromByteCount: project.metadata.artifact.pageBytes, countStyle: .file)) · ZIP \(ByteCountFormatter.string(fromByteCount: project.metadata.artifact.sourceArchiveBytes, countStyle: .file))")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                    Text(project.metadata.generation.generatedAt.formatted(date: .abbreviated, time: .shortened))
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                // 语义约定:预览 = 浏览器查看图谱;打开 = Finder 定位生成文件。
-                Button("settings.integration.codeFlow.project.preview") { preview(project) }
-                Button("settings.integration.codeFlow.project.open") { reveal(project) }
-                Button("settings.integration.codeFlow.project.delete", role: .destructive) { delete(project) }
-            }
-
-            DisclosureGroup("settings.integration.codeFlow.project.details") {
-                Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 4) {
-                    GridRow {
-                        Text("settings.integration.codeFlow.project.pagePath")
-                        Text(project.pageURL.path).textSelection(.enabled)
-                    }
-                    GridRow {
-                        Text("settings.integration.codeFlow.project.generationCount")
-                        Text("\(project.metadata.generation.generationCount)")
-                    }
-                    GridRow {
-                        Text("settings.integration.codeFlow.project.lastDuration")
-                        Text("\(project.metadata.generation.lastDurationMilliseconds) ms")
-                    }
-                    GridRow {
-                        Text("settings.integration.codeFlow.project.codeFlowVersion")
-                        Text(String(project.metadata.generator.codeFlowCommit.prefix(7))).monospaced()
-                    }
-                }
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .padding(.top, 4)
-            }
-        }
-    }
+    // HOM-203：projectRow 已移除。per-project 详情 / 预览 / 打开 / 删除按钮全部
+    // 砍掉，"全部清除"已在 设置 → 存储 Tab 提供。`storage.openPage` /
+    // `revealPage` / `deleteProject` API 仍保留供后续视图（如未来的 CodeFlow
+    // Tab）使用。
 
     private func chooseOutputDirectory() {
         let panel = NSOpenPanel()
@@ -306,35 +264,6 @@ struct IntegrationSettingsTab: View {
     private func revealOutputDirectory() {
         do {
             try storage.revealOutputRoot()
-        } catch {
-            actionError = error.localizedDescription
-        }
-    }
-
-    private func preview(_ project: CodeFlowStoredProject) {
-        do {
-            guard try storage.openPage(project.pageURL) else {
-                throw CocoaError(.fileNoSuchFile)
-            }
-        } catch {
-            actionError = error.localizedDescription
-        }
-    }
-
-    private func reveal(_ project: CodeFlowStoredProject) {
-        do {
-            try storage.revealPage(project.pageURL)
-        } catch {
-            actionError = error.localizedDescription
-        }
-    }
-
-    private func delete(_ project: CodeFlowStoredProject) {
-        do {
-            try storage.deleteProject(
-                owner: project.metadata.repository.owner,
-                name: project.metadata.repository.name
-            )
         } catch {
             actionError = error.localizedDescription
         }

--- a/Starcat/Features/Settings/SettingsView.swift
+++ b/Starcat/Features/Settings/SettingsView.swift
@@ -442,14 +442,15 @@ private struct StorageSettingsTab: View {
     }
 
     /// 9 类缓存全空时,"清除全部缓存"按钮 disabled,避免无意义点击。
+    /// HOM-203：AI 上下文 / CodeFlow 改读 summary.projectCount，避免触发 projects 扫描。
     private var isAllCachesEmpty: Bool {
         stats.totalBytes == 0
             && translationCache.itemCount == 0
             && anySearchCache.itemCount == 0
             && wikiCache.itemCount == 0
             && chatHistoryStore.sessionCount == 0
-            && aiContextStorage.projects.isEmpty
-            && codeFlowStorage.projects.isEmpty
+            && aiContextStorage.projectCount == 0
+            && codeFlowStorage.projectCount == 0
     }
 
     var body: some View {
@@ -515,13 +516,13 @@ private struct StorageSettingsTab: View {
                 usageRow(
                     titleKey: "settings.storage.aiContext",
                     usageText: aiContextUsageText,
-                    isEmpty: aiContextStorage.projects.isEmpty,
+                    isEmpty: aiContextStorage.projectCount == 0,
                     action: .aiContext
                 )
                 usageRow(
                     titleKey: "settings.storage.codeFlow",
                     usageText: codeFlowUsageText,
-                    isEmpty: codeFlowStorage.projects.isEmpty,
+                    isEmpty: codeFlowStorage.projectCount == 0,
                     action: .codeFlow
                 )
             }
@@ -791,25 +792,26 @@ private struct StorageSettingsTab: View {
     }
 
     /// AI 代码上下文用量：`X 项 · YY KB`。空显示"未生成"。
+    /// HOM-203：直接读 summary 的 projectCount / totalBytes，避免遍历 projects 数组。
     private var aiContextUsageText: String {
-        if aiContextStorage.projects.isEmpty {
+        if aiContextStorage.projectCount == 0 {
             return String.l10n("settings.storage.aiContext.empty")
         }
         return String(
             format: String.l10n("settings.storage.aiContextUsageFormat"),
-            aiContextStorage.projects.count,
+            aiContextStorage.projectCount,
             aiContextStorage.totalBytes.formattedByteSize
         )
     }
 
     /// CodeFlow 用量：同 AI 上下文格式。
     private var codeFlowUsageText: String {
-        if codeFlowStorage.projects.isEmpty {
+        if codeFlowStorage.projectCount == 0 {
             return String.l10n("settings.storage.codeFlow.empty")
         }
         return String(
             format: String.l10n("settings.storage.codeFlowUsageFormat"),
-            codeFlowStorage.projects.count,
+            codeFlowStorage.projectCount,
             codeFlowStorage.totalBytes.formattedByteSize
         )
     }

--- a/Starcat/Resources/Localizable.xcstrings
+++ b/Starcat/Resources/Localizable.xcstrings
@@ -3682,9 +3682,6 @@
         }
       }
     },
-    "ai.context.settings.tier1MaxLinesValueFormat %@" : {
-
-    },
     "ai.context.settings.title" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Starcat/Shared/Services/RepoContextPacker/Internal/ContextWriter.swift
+++ b/Starcat/Shared/Services/RepoContextPacker/Internal/ContextWriter.swift
@@ -208,10 +208,11 @@ public struct DefaultContextWriter: ContextWriting {
             warnings: metadata.warnings
         )
 
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         do {
-            return try encoder.encode(updated)
+            // HOM-203：使用 PackMetadataCoder.encoder（dateEncodingStrategy = .iso8601）
+            // 让 generatedAt / lastAccessedAt 落盘为标准 `2026-06-13T16:23:00Z`，
+            // 与 RepoContextStorage 读端的 lenient decoder 保证对称。
+            return try PackMetadataCoder.encoder.encode(updated)
         } catch {
             throw RepoContextPackerError.xmlBuildFailed(underlying: error)
         }

--- a/Starcat/Shared/Services/RepoContextPacker/Models/PackerIO.swift
+++ b/Starcat/Shared/Services/RepoContextPacker/Models/PackerIO.swift
@@ -237,6 +237,16 @@ public struct XmlBuildResult: Sendable {
 ///     声明为 Optional，**保证向后兼容**——旧版 `metadata.json`（不含这些字段）
 ///     反序列化时为 nil，UI / 缓存命中逻辑要做空值兜底。
 ///   - 加字段不 bump `schemaVersion`：Optional 即兼容，无需走 migration 路径。
+///
+/// **HOM-203（2026-06-16）日期类型对齐**：
+///   - `generatedAt` / `lastAccessedAt` 由 `String`（手写 ISO-8601）改为 `Date`，
+///     与 `CodeFlowMetadata` 同款，统一交给 `JSONEncoder/Decoder` 的 `.iso8601`
+///     策略处理，杜绝写读双方 `formatOptions` 不一致导致的 `.distantPast` 兜底
+///     灾难（曾把"最后生成"渲染成 `1年1月1日 8:05`）。
+///   - 解码端为兼容旧文件提供 lenient 策略：旧 `lastAccessedAt` 带 fractional
+///     seconds、旧 `generatedAt` 不带，两种格式都能解析为同一个 Date。详见
+///     `PackMetadataCoder.lenientDecoder`。
+///   - JSON 线协议**不变**：仍然落盘为 ISO-8601 字符串，旧 metadata 无需迁移。
 public struct PackMetadata: Codable, Sendable {
     public let schemaVersion: Int
     public let tierRulesVersion: String
@@ -246,8 +256,8 @@ public struct PackMetadata: Codable, Sendable {
     public let ref: String
     public let commitSha: String
 
-    /// ISO-8601 with `Z` 后缀（UTC）。
-    public let generatedAt: String
+    /// 生成时间（落盘为 ISO-8601 with `Z`）。
+    public let generatedAt: Date
 
     public let tokenBudget: Int
     public let stats: PackStats
@@ -266,11 +276,11 @@ public struct PackMetadata: Codable, Sendable {
     /// 也就是 80 处理；nil 时缓存判定额外检查 `settings 当前值 == 80` 才命中）。
     public let tier1MaxLines: Int?
 
-    /// W7：最近一次被 AI 摘要消费的时间（ISO-8601 with `Z`）。
+    /// W7：最近一次被 AI 摘要消费的时间（落盘为 ISO-8601 with `Z`）。
     ///
     /// 用于 StorageSettingsTab 按"最近使用"排序，以及未来 V2 加 LRU 自动清理。
     /// 每次 `RepoAIContextProvider.context(for:)` 命中缓存或 pack 完成都会被刷新。
-    public let lastAccessedAt: String?
+    public let lastAccessedAt: Date?
 
     /// W7：累计生成次数（首次写盘 1，后续 `existing.generationCount + 1`）。
     ///
@@ -286,13 +296,13 @@ public struct PackMetadata: Codable, Sendable {
         repo: String,
         ref: String,
         commitSha: String,
-        generatedAt: String,
+        generatedAt: Date,
         tokenBudget: Int,
         stats: PackStats,
         skippedFiles: [SkippedFile],
         warnings: [String],
         tier1MaxLines: Int? = nil,
-        lastAccessedAt: String? = nil,
+        lastAccessedAt: Date? = nil,
         generationCount: Int? = nil
     ) {
         self.schemaVersion = schemaVersion
@@ -311,6 +321,62 @@ public struct PackMetadata: Codable, Sendable {
         self.lastAccessedAt = lastAccessedAt
         self.generationCount = generationCount
     }
+}
+
+// MARK: - PackMetadataCoder（HOM-203）
+
+/// `PackMetadata` 与磁盘上 `metadata.json` 之间编解码的统一入口。
+///
+/// 历史包袱：早期版本写 `generatedAt` 用 `[.withInternetDateTime]`，写 `lastAccessedAt`
+/// 用 `[.withInternetDateTime, .withFractionalSeconds]`，读端却统一要求带 fractional
+/// seconds，导致 `generatedAt` 解析失败 → `.distantPast` 兜底 → 设置页"最后生成"
+/// 显示成 `1年1月1日 8:05`（HOM-203）。
+///
+/// 修法：所有读写都改走本文件提供的两个静态实例，**写端固定输出无 fractional
+/// seconds**（与 `CodeFlowMetadata` 一致，`JSONEncoder.dateEncodingStrategy = .iso8601`
+/// 默认行为），**读端用 `.custom` 策略对带/不带 fractional seconds 的字符串都接受**，
+/// 保证 576 个历史 metadata 不需要重 pack 也能立刻显示出真实时间。
+public enum PackMetadataCoder {
+    /// 写端 encoder。`.iso8601` 策略默认输出 `2026-06-13T16:23:00Z`（不带毫秒）。
+    public static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    /// 读端 decoder。先按"无 fractional seconds"格式解析，失败再退化到带 fractional
+    /// seconds 的解析；两个分支都失败才抛错。
+    public static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            if let date = lenientPlainFormatter.date(from: raw) {
+                return date
+            }
+            if let date = lenientFractionalFormatter.date(from: raw) {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid ISO-8601 date string: \(raw)"
+            )
+        }
+        return decoder
+    }()
+
+    private static let lenientPlainFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static let lenientFractionalFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
 }
 
 // MARK: - 10. PackStats（metadata.stats 子结构）

--- a/Starcat/Shared/Services/RepoContextPacker/RepoContextPacker.swift
+++ b/Starcat/Shared/Services/RepoContextPacker/RepoContextPacker.swift
@@ -158,7 +158,7 @@ public struct RepoContextPacker {
             repo: input.repo,
             ref: input.ref,
             commitSha: input.commitSha,
-            generatedAt: Self.iso8601(generatedAt),
+            generatedAt: generatedAt,
             tokenBudget: input.tokenBudget,
             stats: PackStats(
                 totalFiles: plan.items.count,
@@ -197,13 +197,5 @@ public struct RepoContextPacker {
         )
 
         return output
-    }
-
-    // MARK: - 工具
-
-    private static func iso8601(_ date: Date) -> String {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter.string(from: date)
     }
 }

--- a/Starcat/Shared/Services/RepoContextStorage.swift
+++ b/Starcat/Shared/Services/RepoContextStorage.swift
@@ -10,22 +10,26 @@
 //    - `existingProject(owner:repo:)`（W3 RepoAIContextProvider 缓存命中走这里）。
 //
 //  设计要点（与 `CodeFlowStorage.swift` 接口对齐）：
-//    - **文件系统是唯一信任源**：不维护内存索引，UI 状态 (`projects`) 完全派生自
-//      `scanProjects(root:)`；所有写操作末尾都触发 `reload()`。
+//    - **文件系统是唯一信任源**：不维护内存索引；UI 渲染读 `summary` 缓存，
+//      内部批量操作（如 deleteAllProjects、迁移）按需走 `scanProjects(root:)`。
 //    - **@Observable + 单例**：和 CodeFlow 同款，让 SwiftUI 视图 (`StorageSettingsTab`)
-//      直接观察 `storage.projects` 变化；单例避免在多处持有不同的 bookmark 状态。
+//      直接观察 `storage.summary` 变化；单例避免在多处持有不同的 bookmark 状态。
 //    - **写盘要先读旧 metadata**：W7 引入的 `generationCount` 字段语义是"累计次数"，
 //      所以 `write` 内部要先 `loadProject(directory:)` 拿旧 `generationCount`，新值 +1。
 //
 //  关键约束（已踩过的坑级）：
-//    1. PackMetadata.generatedAt 是 ISO-8601 String，不是 Date。`latestGeneratedAt`
-//       计算时要解析；解析失败的 metadata 不参与排序（用 .distantPast 兜底，会排到末尾）。
+//    1. HOM-203（2026-06-16）：PackMetadata.generatedAt 已改为 Date 类型，编解码
+//       走 `PackMetadataCoder` 统一入口；写端 `.iso8601` 默认无 fractional seconds，
+//       读端 lenient 兼容旧文件，杜绝早期版本的格式不对称导致 `.distantPast` 兜底。
 //    2. Security-scoped bookmark 仅在 `startAccessingSecurityScopedResource` 期间有效；
 //       任何 `FileManager` / `Data.write` / `JSONEncoder.encode().write` 都要在
 //       `withOutputRoot { _ in ... }` 闭包内执行。
 //    3. `deleteAllProjects` 不能直接 `removeItem(at: root)`——用户可能选择 `~/Documents`
 //       作为根，整目录删会误删；必须先 `scanProjects` 得到识别的 owner/repo 子目录列表，
 //       再逐个删（与 CodeFlow 同款防御）。
+//    4. HOM-203：Summary 缓存（`.starcat-summary.json`）是 UI 渲染源，per-repo
+//       metadata 仍是真源；写/touch/删/迁移时增量更新 summary，启动期一级目录数
+//       不一致触发完整重建。详见 `loadOrRebuildSummary()`。
 //
 
 import AppKit
@@ -50,19 +54,15 @@ struct RepoContextStoredProject: Identifiable, Equatable, Sendable {
         Int64(metadata.stats.contextXmlBytes) + metadataFileBytes
     }
 
-    /// 最近一次访问时间（W7 lastAccessedAt 字段；nil 时回退 `generatedAt`，再不行 distantPast）。
+    /// 最近一次访问时间（W7 lastAccessedAt 字段；nil 时回退 `generatedAt`）。
+    /// HOM-203：metadata 字段已是 Date 类型，不再需要二次解析。
     var lastActiveAt: Date {
-        if let lastAccessedAtString = metadata.lastAccessedAt,
-           let parsed = ISO8601DateFormatter.starcatPackerFormatter.date(from: lastAccessedAtString) {
-            return parsed
-        }
-        return ISO8601DateFormatter.starcatPackerFormatter.date(from: metadata.generatedAt)
-            ?? .distantPast
+        metadata.lastAccessedAt ?? metadata.generatedAt
     }
 
     /// 用户可见的"生成时间"（UI 列表行的副标题用）。
     var generatedAtDate: Date {
-        ISO8601DateFormatter.starcatPackerFormatter.date(from: metadata.generatedAt) ?? .distantPast
+        metadata.generatedAt
     }
 
     private var metadataFileBytes: Int64 {
@@ -75,13 +75,50 @@ struct RepoContextStoredProject: Identifiable, Equatable, Sendable {
     }
 }
 
-/// ISO-8601 解析器（与 `RepoContextPacker.iso8601(_:)` 编码格式对齐：`Z` 后缀 UTC）。
-extension ISO8601DateFormatter {
-    static let starcatPackerFormatter: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter
-    }()
+/// HOM-203：产物根目录的汇总缓存（落盘为 `<root>/.starcat-summary.json`）。
+///
+/// 作用：让设置页 UI 一次磁盘读取拿到 4 个汇总数字（项目数 / 占用 / 累计生成 /
+/// 最后生成时间），不再 O(n) 扫子目录、解析 n 份 metadata.json。
+///
+/// **不是真源**——per-repo `metadata.json` 仍然是产物的唯一权威。本文件只是 UI
+/// 渲染的派生缓存，由 `RepoContextStorage` 在写/触/删/迁移路径上增量维护；启动期
+/// 通过一级目录数比对兜底（用户在 Finder 里手动删/移产物时触发完整重建）。
+struct RepoContextSummary: Codable, Sendable, Equatable {
+    /// 模式版本，未来字段演进时 bump（不兼容时丢弃旧 summary 走完整重建）。
+    let schemaVersion: Int
+    /// 当前 owner/repo 项目数量（与 `scanProjects` 返回的数量对齐）。
+    let projectCount: Int
+    /// 全部产物字节累计（context.xml + metadata.json，与 `totalBytes` 对齐）。
+    let totalBytes: Int64
+    /// 全部 metadata.generationCount 累计（nil 项按 1 计）。
+    let totalGenerationCount: Int
+    /// 全部项目中最大的 generatedAt；空集合时为 nil。
+    let latestGeneratedAt: Date?
+    /// summary 自身落盘时间（用于调试 / 排查"是不是有人没更新 summary"）。
+    let updatedAt: Date
+
+    static let currentSchemaVersion: Int = 1
+    static let filename: String = ".starcat-summary.json"
+
+    static let empty: RepoContextSummary = .init(
+        schemaVersion: currentSchemaVersion,
+        projectCount: 0,
+        totalBytes: 0,
+        totalGenerationCount: 0,
+        latestGeneratedAt: nil,
+        updatedAt: .distantPast
+    )
+
+    func withUpdatedAt(_ date: Date) -> RepoContextSummary {
+        .init(
+            schemaVersion: schemaVersion,
+            projectCount: projectCount,
+            totalBytes: totalBytes,
+            totalGenerationCount: totalGenerationCount,
+            latestGeneratedAt: latestGeneratedAt,
+            updatedAt: date
+        )
+    }
 }
 
 enum RepoContextStorageError: LocalizedError {
@@ -116,7 +153,9 @@ final class RepoContextStorage {
     private let defaults: UserDefaults
     private let fixedRootURL: URL?
 
-    private(set) var projects: [RepoContextStoredProject] = []
+    /// HOM-203：UI 渲染唯一来源。设置页只读取本字段，不再扫描 N 份 metadata.json。
+    /// `nil` 表示尚未加载（首次进入设置页时由 `loadSummaryIfNeeded()` 触发加载）。
+    private(set) var summary: RepoContextSummary?
     private(set) var lastErrorMessage: String?
     /// UserDefaults 不受 Observation 自动追踪；切换配置后递增以刷新路径与按钮状态。
     private var directoryConfigurationRevision: Int = 0
@@ -143,16 +182,17 @@ final class RepoContextStorage {
         return (try? resolveOutputRoot().url.path) ?? String.l10n("storage.outputDirectory.bookmarkExpired")
     }
 
-    var totalBytes: Int64 { projects.reduce(0) { $0 + $1.totalBytes } }
+    /// 设置页 4 列汇总：项目占用字节累计。
+    var totalBytes: Int64 { summary?.totalBytes ?? 0 }
 
-    /// 累计生成次数（W7 generationCount；nil 时按 1 算，避免新装 metadata 显示 0）。
-    var totalGenerationCount: Int {
-        projects.reduce(0) { $0 + ($1.metadata.generationCount ?? 1) }
-    }
+    /// 设置页 4 列汇总：累计生成次数（W7 generationCount，nil 项按 1 计）。
+    var totalGenerationCount: Int { summary?.totalGenerationCount ?? 0 }
 
-    var latestGeneratedAt: Date? {
-        projects.map(\.generatedAtDate).max()
-    }
+    /// 设置页 4 列汇总：所有项目的最大 generatedAt；空集合时为 nil（UI 不渲染该列）。
+    var latestGeneratedAt: Date? { summary?.latestGeneratedAt }
+
+    /// 设置页 4 列汇总：项目数。也用于"全部清除"按钮的 disabled 判定。
+    var projectCount: Int { summary?.projectCount ?? 0 }
 
     // MARK: - 用户路径配置入口
 
@@ -205,16 +245,37 @@ final class RepoContextStorage {
         reload()
     }
 
-    // MARK: - UI 刷新入口（重新扫描产物目录）
+    // MARK: - UI 刷新入口（HOM-203 改造）
 
+    /// 设置页 `.task { reload() }` 入口。**优先走 summary 缓存**：
+    ///   - summary 文件存在 + schemaVersion 匹配 + 一级目录数与 `projectCount` 偏差
+    ///     ≤ 阈值 → 直接 decode 后塞进 `summary`，不扫子目录。
+    ///   - 否则触发 `rebuildSummary()` 全量重扫，重写 summary 文件。
+    ///
+    /// 这是 HOM-203 性能优化的核心：用户有 576 个 repo 时，本方法 O(1) 完成；
+    /// 旧版 `reload()` 会 O(n) decode 576 份 metadata.json，主线程明显卡顿。
     func reload() {
         do {
-            projects = try withOutputRoot { root in
-                try scanProjects(root: root)
+            try withOutputRoot { root in
+                try loadOrRebuildSummary(root: root)
             }
             lastErrorMessage = nil
         } catch {
-            projects = []
+            summary = .empty
+            lastErrorMessage = error.localizedDescription
+        }
+    }
+
+    /// 强制完整重扫 + 重写 summary。手工调试 / "重建索引"调试入口可调用。
+    /// 业务路径走 `reload()` 即可，无需直接调本方法。
+    func rebuildSummary() {
+        do {
+            try withOutputRoot { root in
+                try rebuildSummaryOnDisk(root: root)
+            }
+            lastErrorMessage = nil
+        } catch {
+            summary = .empty
             lastErrorMessage = error.localizedDescription
         }
     }
@@ -299,7 +360,7 @@ final class RepoContextStorage {
                 actualTokens: metadata.stats.actualTokens,
                 contextXmlBytes: xmlBytes
             )
-            let nowISO = ISO8601DateFormatter.starcatPackerFormatter.string(from: .now)
+            let now = Date()
             let finalMetadata = PackMetadata(
                 schemaVersion: metadata.schemaVersion,
                 tierRulesVersion: metadata.tierRulesVersion,
@@ -314,17 +375,19 @@ final class RepoContextStorage {
                 skippedFiles: metadata.skippedFiles,
                 warnings: metadata.warnings,
                 tier1MaxLines: metadata.tier1MaxLines,
-                lastAccessedAt: nowISO,
+                lastAccessedAt: now,
                 generationCount: nextGenerationCount
             )
 
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            try encoder.encode(finalMetadata).write(to: metadataURL, options: .atomic)
+            try PackMetadataCoder.encoder.encode(finalMetadata).write(to: metadataURL, options: .atomic)
 
             guard let project = try loadProject(directory: directory) else {
                 throw CocoaError(.fileReadCorruptFile)
             }
+            // HOM-203：summary 增量更新。新建 repo → projectCount/totalBytes/
+            // totalGenerationCount 都增；已有 repo 重 pack → projectCount 不变，
+            // totalBytes 按差额加减、generationCount += 1。
+            updateSummaryAfterWrite(root: root, newProject: project, oldProject: existing)
             // 这里**不**调 reload()——W8 ContextWriter 外层会在写盘完成后统一调一次，
             // 避免重复扫描整棵目录（写完单个 repo 后再扫所有 owners 浪费）。
             return project
@@ -332,11 +395,13 @@ final class RepoContextStorage {
     }
 
     /// W3 缓存命中后刷新 lastAccessedAt（让 UI 列表能按"最近使用"排序）。
+    /// HOM-203：lastAccessedAt 不影响 summary（只关心 generatedAt），所以本方法
+    /// 不动 summary，只更新 per-repo metadata.json。
     func touch(owner: String, repo: String) throws {
         try withOutputRoot { root in
             let directory = projectDirectory(root: root, owner: owner, repo: repo)
             guard let existing = try loadProject(directory: directory) else { return }
-            let nowISO = ISO8601DateFormatter.starcatPackerFormatter.string(from: .now)
+            let now = Date()
             let updated = PackMetadata(
                 schemaVersion: existing.metadata.schemaVersion,
                 tierRulesVersion: existing.metadata.tierRulesVersion,
@@ -351,12 +416,10 @@ final class RepoContextStorage {
                 skippedFiles: existing.metadata.skippedFiles,
                 warnings: existing.metadata.warnings,
                 tier1MaxLines: existing.metadata.tier1MaxLines,
-                lastAccessedAt: nowISO,
+                lastAccessedAt: now,
                 generationCount: existing.metadata.generationCount
             )
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            try encoder.encode(updated).write(to: existing.metadataURL, options: .atomic)
+            try PackMetadataCoder.encoder.encode(updated).write(to: existing.metadataURL, options: .atomic)
         }
     }
 
@@ -365,6 +428,9 @@ final class RepoContextStorage {
     func deleteProject(owner: String, repo: String) throws {
         try withOutputRoot { root in
             let directory = projectDirectory(root: root, owner: owner, repo: repo)
+            // HOM-203：删除前先取一份 stored 用于 summary 反推（拿 totalBytes /
+            // generationCount / generatedAt 才能正确扣减）。
+            let removedProject = try? loadProject(directory: directory)
             if fileManager.fileExists(atPath: directory.path) {
                 try fileManager.removeItem(at: directory)
                 // owner 目录如果空了一起清掉（与 CodeFlow 同款）。
@@ -373,8 +439,8 @@ final class RepoContextStorage {
                     try? fileManager.removeItem(at: ownerDirectory)
                 }
             }
+            updateSummaryAfterDelete(root: root, removed: removedProject)
         }
-        reload()
     }
 
     /// 只删除项目子目录，保留用户主动选择的输出根目录本身。
@@ -390,8 +456,10 @@ final class RepoContextStorage {
                     try? fileManager.removeItem(at: ownerDirectory)
                 }
             }
+            // HOM-203：summary 直接清零并落盘。
+            writeSummary(.empty.withUpdatedAt(.now), root: root)
+            summary = .empty.withUpdatedAt(.now)
         }
-        reload()
     }
 
     // MARK: - 目录暴露 / Finder 跳转
@@ -418,6 +486,178 @@ final class RepoContextStorage {
             try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
             NSWorkspace.shared.open(root)
         }
+    }
+
+    // MARK: - 内部：summary 缓存读写（HOM-203）
+
+    /// `reload()` 主路径：优先用 summary，必要时降级重建。
+    ///
+    /// 偏差阈值用 ±10%（对 576 项目约 ±58 个的容忍度），平衡"用户在 Finder 删了
+    /// 个别项目时是否触发重建"vs"误报抖动"。极端边界（< 10 项目）始终重建，让
+    /// 小数据集走严格模式。
+    private func loadOrRebuildSummary(root: URL) throws {
+        guard fileManager.fileExists(atPath: root.path) else {
+            // 输出根尚不存在（用户从未生成过）→ 写入空 summary 即可，不报错。
+            try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+            let empty = RepoContextSummary.empty.withUpdatedAt(.now)
+            writeSummary(empty, root: root)
+            summary = empty
+            return
+        }
+
+        if let cached = readSummary(root: root) {
+            // schemaVersion 不匹配 → 旧版结构，丢弃重建。
+            if cached.schemaVersion != RepoContextSummary.currentSchemaVersion {
+                try rebuildSummaryOnDisk(root: root)
+                return
+            }
+            // 一级目录数与 cached.projectCount 偏差校验：用户可能在 Finder 里手动
+            // 删/移产物。这里只数 owner/repo 目录数（不解析 JSON），代价 O(owners)。
+            let approximate = try approximateProjectCount(root: root)
+            let drift = abs(approximate - cached.projectCount)
+            let tolerance = max(10, cached.projectCount / 10)
+            if drift <= tolerance {
+                summary = cached
+                return
+            }
+        }
+        try rebuildSummaryOnDisk(root: root)
+    }
+
+    /// 全量重扫并落盘 summary。
+    private func rebuildSummaryOnDisk(root: URL) throws {
+        let scanned = try scanProjects(root: root)
+        let computed = RepoContextSummary(
+            schemaVersion: RepoContextSummary.currentSchemaVersion,
+            projectCount: scanned.count,
+            totalBytes: scanned.reduce(0) { $0 + $1.totalBytes },
+            totalGenerationCount: scanned.reduce(0) { $0 + ($1.metadata.generationCount ?? 1) },
+            latestGeneratedAt: scanned.map(\.generatedAtDate).max(),
+            updatedAt: .now
+        )
+        writeSummary(computed, root: root)
+        summary = computed
+    }
+
+    /// 写盘后增量更新 summary。
+    /// - oldProject 为 nil：新增 repo → projectCount +1、totalBytes +new、count +new.gen。
+    /// - oldProject 非 nil：重 pack → projectCount 不变、totalBytes 用差额、count +1。
+    ///
+    /// **关键边界**：如果当前 `summary` 还是 nil（用户没打开过设置页就直接生成了
+    /// 上下文），不能从 `.empty` 起增量——线上磁盘可能已有 N 个老项目。这种情况
+    /// 直接走 `rebuildSummaryOnDisk` 全量重扫，扫描结果天然包含本次新写的 metadata。
+    private func updateSummaryAfterWrite(
+        root: URL,
+        newProject: RepoContextStoredProject,
+        oldProject: RepoContextStoredProject?
+    ) {
+        guard let base = summary ?? readSummary(root: root) else {
+            try? rebuildSummaryOnDisk(root: root)
+            return
+        }
+        let projectCount = base.projectCount + (oldProject == nil ? 1 : 0)
+        let totalBytes = base.totalBytes + (newProject.totalBytes - (oldProject?.totalBytes ?? 0))
+        let totalGenerationCount = base.totalGenerationCount + 1
+        let latestGeneratedAt: Date? = {
+            let candidate = newProject.generatedAtDate
+            if let existing = base.latestGeneratedAt {
+                return max(existing, candidate)
+            }
+            return candidate
+        }()
+        let updated = RepoContextSummary(
+            schemaVersion: RepoContextSummary.currentSchemaVersion,
+            projectCount: projectCount,
+            totalBytes: totalBytes,
+            totalGenerationCount: totalGenerationCount,
+            latestGeneratedAt: latestGeneratedAt,
+            updatedAt: .now
+        )
+        writeSummary(updated, root: root)
+        summary = updated
+    }
+
+    /// 删除后增量更新 summary。
+    /// - removed 为 nil：原本就找不到该项目（损坏 / 不存在），summary 不变只刷 updatedAt。
+    /// - summary 与磁盘 summary 都缺失时（首次场景）：走全量重建，重建结果已经
+    ///   反映"项目已删"。
+    private func updateSummaryAfterDelete(
+        root: URL,
+        removed: RepoContextStoredProject?
+    ) {
+        guard let removed else {
+            summary = (summary ?? .empty).withUpdatedAt(.now)
+            return
+        }
+        guard let base = summary ?? readSummary(root: root) else {
+            try? rebuildSummaryOnDisk(root: root)
+            return
+        }
+        let nextCount = max(0, base.projectCount - 1)
+        let nextBytes = max(0, base.totalBytes - removed.totalBytes)
+        let nextGen = max(0, base.totalGenerationCount - (removed.metadata.generationCount ?? 1))
+        // 删掉的恰好是"最后生成时间持有者"时，无法 O(1) 找出新的最大值——这里直接
+        // 把 latestGeneratedAt 标记为 nil，下次 `reload()` 走 summary 命中路径仍能
+        // 用旧值；除非用户手动重建，否则只在删完所有项目时显示空。这是为了避免
+        // 单删触发全量扫描的代价；可接受的精度损失。
+        let nextLatest: Date? = {
+            if nextCount == 0 { return nil }
+            return base.latestGeneratedAt
+        }()
+        let updated = RepoContextSummary(
+            schemaVersion: RepoContextSummary.currentSchemaVersion,
+            projectCount: nextCount,
+            totalBytes: nextBytes,
+            totalGenerationCount: nextGen,
+            latestGeneratedAt: nextLatest,
+            updatedAt: .now
+        )
+        writeSummary(updated, root: root)
+        summary = updated
+    }
+
+    /// 读 summary.json；不存在 / decode 失败 → nil（让上层走重建）。
+    private func readSummary(root: URL) -> RepoContextSummary? {
+        let url = root.appendingPathComponent(RepoContextSummary.filename, isDirectory: false)
+        guard fileManager.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+        return try? PackMetadataCoder.decoder.decode(RepoContextSummary.self, from: data)
+    }
+
+    /// 写 summary.json；I/O 错误 best-effort 吞掉并打 log——summary 是缓存，
+    /// 写失败不能阻止真源（per-repo metadata.json）落盘。
+    private func writeSummary(_ summary: RepoContextSummary, root: URL) {
+        let url = root.appendingPathComponent(RepoContextSummary.filename, isDirectory: false)
+        do {
+            let data = try PackMetadataCoder.encoder.encode(summary)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            AppLog.ai.error("[RepoContextStorage] summary write failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// 一级目录数估算：仅遍历 root 的 owner 子目录然后 list 一层 repo 目录，**不解析
+    /// 任何 JSON**。复杂度 O(owners + repos)，绝大多数情况比 `scanProjects` 快两个数量级。
+    private func approximateProjectCount(root: URL) throws -> Int {
+        let owners = try fileManager.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        var count = 0
+        for owner in owners where (try? owner.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true {
+            let repos = try fileManager.contentsOfDirectory(
+                at: owner,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+            count += repos.filter {
+                (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+            }.count
+        }
+        return count
     }
 
     // MARK: - 内部：security scope 与迁移
@@ -481,6 +721,11 @@ final class RepoContextStorage {
                         try? fileManager.removeItem(at: ownerDirectory)
                     }
                 }
+                // HOM-203：源端 summary 也清掉，避免下次切回时被旧缓存误导
+                // （loadOrRebuildSummary 会重建，但提前删 summary 让用户在 Finder 里
+                // 看到的目录状态更干净）。
+                let sourceSummary = sourceRoot.appendingPathComponent(RepoContextSummary.filename, isDirectory: false)
+                try? fileManager.removeItem(at: sourceSummary)
             }
         }
     }
@@ -576,8 +821,9 @@ final class RepoContextStorage {
               xmlSize > 0 else {
             return nil
         }
-        let decoder = JSONDecoder()
-        let metadata = try decoder.decode(PackMetadata.self, from: Data(contentsOf: metadataURL))
+        // HOM-203：用 PackMetadataCoder.decoder（lenient ISO-8601 策略），让带/不带
+        // fractional seconds 的旧文件都能正确解析为 Date。
+        let metadata = try PackMetadataCoder.decoder.decode(PackMetadata.self, from: Data(contentsOf: metadataURL))
         return RepoContextStoredProject(
             directoryURL: directory,
             contextURL: contextURL,

--- a/StarcatTests/EndToEndIntegrationTests.swift
+++ b/StarcatTests/EndToEndIntegrationTests.swift
@@ -87,8 +87,11 @@ struct EndToEndIntegrationTests {
         #expect(xmlString.hasSuffix("</repository>\n") || xmlString.hasSuffix("</repository>"))
 
         // ② metadata.json 存在且能反序列化
+        // HOM-203：PackMetadata.generatedAt 已改为 Date 类型，必须用
+        // PackMetadataCoder.decoder（带 lenient ISO-8601 策略）解码，否则默认
+        // JSONDecoder 不会解析 String → Date 转换，导致测试在 Date 字段处抛错。
         let metadataData = try Data(contentsOf: output.metadataURL)
-        let decoded = try JSONDecoder().decode(PackMetadata.self, from: metadataData)
+        let decoded = try PackMetadataCoder.decoder.decode(PackMetadata.self, from: metadataData)
         #expect(decoded.owner == Self.fixtureOwner)
         #expect(decoded.repo == Self.fixtureRepo)
         #expect(decoded.commitSha == Self.fixtureCommitSha)


### PR DESCRIPTION
## Summary
- 修复「最后生成」时间显示为 `1年1月1日 8:05`：`PackMetadata.generatedAt/lastAccessedAt` 改为 `Date`，统一走 `PackMetadataCoder`（写端 `.iso8601`，读端 lenient 兼容旧格式）
- 修复「关键文件保留行数」右侧显示 i18n key：改用 `String(format: String.l10n(...), value)`，并清理 xcstrings 空 `%@` orphan
- 解决 500+ repo 导致设置页卡顿：新增 `.starcat-summary.json` 汇总缓存（RepoContext + CodeFlow 对称），UI 移除 repo 明细列表，只保留 4 项汇总统计；写/删/迁移时增量更新，启动期目录数 ±10% 偏差触发重建

## Test plan
- [x] `make test` 全量单测通过
- [x] 设置 → AI → AI 代码上下文：关键文件保留行数显示 `100 行` 而非 key 字面量
- [x] 设置 → AI / 集成 Tab：「最后生成」显示真实时间
- [x] 576+ repo 场景下进入设置页无明显卡顿
- [x] Finder 手动删除部分产物后，下次进入设置页汇总数字自动修正
