### PR TITLE
docs(readme): 增加三段产品演示视频

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -48,6 +48,20 @@ Starcat 一开始是按收费产品来做的，上线后几乎没人买。把 Gi
 
 当前公开版本为 **Starcat 1.4.0**。
 
+## 看看 Starcat 如何工作
+
+### AI 驱动的仓库理解
+
+https://github.com/user-attachments/assets/bf229a76-7a26-4f82-a3b2-1c4d3c960a7f
+
+### 向知识库提问
+
+https://github.com/user-attachments/assets/4785fa1e-d629-4a18-b266-6fa2145f92dd
+
+### 同时搜索本地、GitHub 与 Web
+
+https://github.com/user-attachments/assets/0257850a-d65b-4d9a-9621-028064b7a873
+
 ## 官方包和自己编译
 
 官方渠道是 Mac App Store（[Starcat for GitHub](https://apps.apple.com/cn/app/starcat-for-github/id6788809803?mt=12)，落地页 [dong4j.app/starcat](https://dong4j.app/starcat/)）和 Direct（官网 DMG / Homebrew + Sparkle）。核心整理能力可免费使用。官方包里的 Pro 工作流、更高 AI 配额和代码智能，走 App Store 内购或 Direct 授权。

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ Starcat started as a paid product. Almost nobody bought it. Managing GitHub Star
 
 The current public version is **Starcat 1.4.0**.
 
+## See Starcat in action
+
+### AI-powered repository understanding
+
+https://github.com/user-attachments/assets/bf229a76-7a26-4f82-a3b2-1c4d3c960a7f
+
+### Ask your knowledge base
+
+https://github.com/user-attachments/assets/4785fa1e-d629-4a18-b266-6fa2145f92dd
+
+### Search locally, on GitHub, and across the web
+
+https://github.com/user-attachments/assets/0257850a-d65b-4d9a-9621-028064b7a873
+
 ## Official builds and source
 
 Official channels are the Mac App Store ([Starcat for GitHub](https://apps.apple.com/app/starcat-for-github/id6788809803?mt=12), landing page [dong4j.app/starcat](https://dong4j.app/starcat/)) and Direct (website DMG / Homebrew with Sparkle). Core organization features are free. Pro workflows, higher AI quotas, and code-intelligence features in official builds use App Store in-app purchase or a Direct license.


### PR DESCRIPTION
## 内容

- 在英文 README 增加三段 Starcat 产品演示
- 在中文 README 同步增加对应演示
- 视频使用 GitHub user-attachments 托管，不把 MP4 写入 Git 历史

## 验证

- 三个视频均转码为 H.264/AAC、1280x720，单文件小于 4 MB
- 三个附件地址均可解析为 video/mp4
- git diff --check 通过